### PR TITLE
Picopass standard key

### DIFF
--- a/picopass/application.fam
+++ b/picopass/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="App to communicate with NFC tags using the PicoPass(iClass) format",
-    fap_version="1.2",
+    fap_version="1.3",
     fap_icon="125_10px.png",
     fap_category="NFC",
     fap_libs=["mbedtls"],

--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -95,11 +95,24 @@ void picopass_scene_read_card_success_on_enter(void* context) {
 
         if(pacs->key) {
             furi_string_cat_printf(key_str, "Key: ");
-
             uint8_t key[RFAL_PICOPASS_BLOCK_LEN];
             memcpy(key, &pacs->key, RFAL_PICOPASS_BLOCK_LEN);
+
+            bool standard_key = true;
+            // Handle DES key being 56bits with parity in LSB
             for(uint8_t i = 0; i < RFAL_PICOPASS_BLOCK_LEN; i++) {
-                furi_string_cat_printf(key_str, "%02X", key[i]);
+                if((key[i] & 0xFE) != (picopass_iclass_key[i] & 0xFE)) {
+                    standard_key = false;
+                    break;
+                }
+            }
+
+            if(standard_key) {
+                furi_string_cat_printf(key_str, "Standard");
+            } else {
+                for(uint8_t i = 0; i < RFAL_PICOPASS_BLOCK_LEN; i++) {
+                    furi_string_cat_printf(key_str, "%02X", key[i]);
+                }
             }
         }
 


### PR DESCRIPTION
# What's new

- Shows "standard" if the key is standard, since most people don't recognize it offhand.


# Verification 

- Scan a standard keyed iClass and see "standard"

![Screenshot-20230828-205308](https://github.com/flipperdevices/flipperzero-good-faps/assets/115752/9cf74dbb-4600-41b9-aae3-f659c855c4e0)

- Scan a non-standard (elite/custom) keyed iClass and see that key

![Screenshot-20230828-205358](https://github.com/flipperdevices/flipperzero-good-faps/assets/115752/a8c9e4b5-9c4a-4f94-9820-7b1c56811240)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
