### PR TITLE
Optimise picopass crypto to fix timing issues with newer readers.

### DIFF
--- a/picopass/application.fam
+++ b/picopass/application.fam
@@ -17,8 +17,9 @@ App(
     fap_private_libs=[
         Lib(
             name="loclass",
+            cflags=["-O3"],
         ),
     ],
     fap_icon_assets="icons",
-    fap_file_assets="files"
+    fap_file_assets="files",
 )

--- a/picopass/application.fam
+++ b/picopass/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="App to communicate with NFC tags using the PicoPass(iClass) format",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_icon="125_10px.png",
     fap_category="NFC",
     fap_libs=["mbedtls"],

--- a/picopass/loclass_writer.c
+++ b/picopass/loclass_writer.c
@@ -38,6 +38,8 @@ void loclass_writer_free(LoclassWriter* instance) {
 }
 
 bool loclass_writer_write_start_stop(LoclassWriter* instance, bool start) {
+    furi_assert(instance != NULL);
+
     FuriHalRtcDateTime curr_dt;
     furi_hal_rtc_get_datetime(&curr_dt);
     uint32_t curr_ts = furi_hal_rtc_datetime_to_timestamp(&curr_dt);

--- a/picopass/picopass_worker.c
+++ b/picopass/picopass_worker.c
@@ -1054,13 +1054,15 @@ static void picopass_emu_handle_packet(
         uint8_t rmac[4];
         loclass_opt_doBothMAC_2(ctx->cipher_state, nfcv_data->frame + 1, rmac, response, key);
 
+#ifndef PICOPASS_DEBUG_IGNORE_BAD_RMAC
         if(memcmp(nfcv_data->frame + 5, rmac, 4)) {
             // Bad MAC from reader, do not send a response.
             FURI_LOG_I(TAG, "Got bad MAC from reader");
-#ifndef PICOPASS_DEBUG_IGNORE_BAD_RMAC
+            // Reset the cipher state since we don't do it in READCHECK
+            picopass_init_cipher_state(nfcv_data, ctx);
             return;
-#endif
         }
+#endif
 
         // CHIPRESPONSE(4)
         response_length = 4;

--- a/picopass/picopass_worker.h
+++ b/picopass/picopass_worker.h
@@ -36,6 +36,7 @@ typedef enum {
     PicopassWorkerEventNoDictFound,
     PicopassWorkerEventLoclassGotMac,
     PicopassWorkerEventLoclassGotStandardKey,
+    PicopassWorkerEventLoclassFileError,
 } PicopassWorkerEvent;
 
 typedef void (*PicopassWorkerCallback)(PicopassWorkerEvent event, void* context);

--- a/picopass/scenes/picopass_scene_loclass.c
+++ b/picopass/scenes/picopass_scene_loclass.c
@@ -40,11 +40,10 @@ bool picopass_scene_loclass_on_event(void* context, SceneManagerEvent event) {
     Picopass* picopass = context;
     bool consumed = false;
 
-    uint32_t loclass_macs_collected =
-        scene_manager_get_scene_state(picopass->scene_manager, PicopassSceneLoclass);
-
     if(event.type == SceneManagerEventTypeCustom) {
         if(event.event == PicopassWorkerEventLoclassGotMac) {
+            uint32_t loclass_macs_collected =
+                scene_manager_get_scene_state(picopass->scene_manager, PicopassSceneLoclass);
             loclass_macs_collected++;
             scene_manager_set_scene_state(
                 picopass->scene_manager, PicopassSceneLoclass, loclass_macs_collected);
@@ -55,6 +54,12 @@ bool picopass_scene_loclass_on_event(void* context, SceneManagerEvent event) {
             consumed = true;
         } else if(event.event == PicopassWorkerEventLoclassGotStandardKey) {
             loclass_set_header(picopass->loclass, "Loclass (Got Std Key)");
+            consumed = true;
+        } else if(event.event == PicopassWorkerEventLoclassFileError) {
+            scene_manager_set_scene_state(picopass->scene_manager, PicopassSceneLoclass, 255);
+            loclass_set_num_macs(picopass->loclass, 255);
+            loclass_set_header(picopass->loclass, "Error Opening Log File");
+            picopass_blink_stop(picopass);
             consumed = true;
         } else if(event.event == PicopassCustomEventViewExit) {
             consumed = scene_manager_previous_scene(picopass->scene_manager);

--- a/picopass/scenes/picopass_scene_saved_menu.c
+++ b/picopass/scenes/picopass_scene_saved_menu.c
@@ -1,11 +1,11 @@
 #include "../picopass_i.h"
 
 enum SubmenuIndex {
-    SubmenuIndexDelete,
     SubmenuIndexInfo,
     SubmenuIndexWrite,
     SubmenuIndexEmulate,
     SubmenuIndexRename,
+    SubmenuIndexDelete,
 };
 
 void picopass_scene_saved_menu_submenu_callback(void* context, uint32_t index) {

--- a/picopass/views/loclass.c
+++ b/picopass/views/loclass.c
@@ -21,6 +21,10 @@ static void loclass_draw_callback(Canvas* canvas, void* model) {
     canvas_set_font(canvas, FontSecondary);
     canvas_draw_str_aligned(canvas, 64, 0, AlignCenter, AlignTop, furi_string_get_cstr(m->header));
 
+    if(m->num_macs == 255) {
+        return;
+    }
+
     float progress = m->num_macs == 0 ? 0 :
                                         (float)(m->num_macs) / (float)(LOCLASS_MACS_TO_COLLECT);
 


### PR DESCRIPTION
# What's new

- Optimises the speed of the picopass crypto. This improves emulation compatibility.

# Verification 

- New versions should work on Signos and OmniKey readers that previously would not respond to the emulation.
- Resolves https://github.com/flipperdevices/flipperzero-good-faps/issues/35

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
