### PR TITLE
Picopass: allow zero keys

### DIFF
--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -37,8 +37,9 @@ void picopass_scene_read_card_success_on_enter(void* context) {
         furi_string_cat_printf(csn_str, "%02X", csn[i]);
     }
 
+    // We can't test the pacs->key in case it is intentionally all 0's and we can't test the key block since it is populated with the diversified key before each key test, so we approximate with the PACS config block being blank.
     bool no_key = picopass_is_memset(
-        AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0x00, RFAL_PICOPASS_BLOCK_LEN);
+        AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, RFAL_PICOPASS_BLOCK_LEN);
     bool empty = picopass_is_memset(
         AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0xFF, RFAL_PICOPASS_BLOCK_LEN);
 

--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -37,7 +37,8 @@ void picopass_scene_read_card_success_on_enter(void* context) {
         furi_string_cat_printf(csn_str, "%02X", csn[i]);
     }
 
-    bool no_key = picopass_is_memset(pacs->key, 0x00, RFAL_PICOPASS_BLOCK_LEN);
+    bool no_key = picopass_is_memset(
+        AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0x00, RFAL_PICOPASS_BLOCK_LEN);
     bool empty = picopass_is_memset(
         AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0xFF, RFAL_PICOPASS_BLOCK_LEN);
 


### PR DESCRIPTION
# What's new

- Allows an elite key of all 00's

# Verification 

- Change a card to have an elite key of all 00's (but don't actually do this, it is just wasteful).
- Add an all 00's key to `iclass_elite_dict_user.txt` in a new "assets" folder in app_data/picopass/
- Run `Elite Dict. Attack`
- See the card data (without this change it'll say "read failed")

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
