### PR TITLE
Picopass: Add haptics to loclass

### DIFF
--- a/picopass/scenes/picopass_scene_loclass.c
+++ b/picopass/scenes/picopass_scene_loclass.c
@@ -45,15 +45,18 @@ bool picopass_scene_loclass_on_event(void* context, SceneManagerEvent event) {
             uint32_t loclass_macs_collected =
                 scene_manager_get_scene_state(picopass->scene_manager, PicopassSceneLoclass);
             loclass_macs_collected++;
+            notification_message(picopass->notifications, &sequence_single_vibro);
             scene_manager_set_scene_state(
                 picopass->scene_manager, PicopassSceneLoclass, loclass_macs_collected);
             loclass_set_num_macs(picopass->loclass, loclass_macs_collected);
             if(loclass_macs_collected >= LOCLASS_MACS_TO_COLLECT) {
+                notification_message(picopass->notifications, &sequence_double_vibro);
                 scene_manager_previous_scene(picopass->scene_manager);
             }
             consumed = true;
         } else if(event.event == PicopassWorkerEventLoclassGotStandardKey) {
             loclass_set_header(picopass->loclass, "Loclass (Got Std Key)");
+            notification_message(picopass->notifications, &sequence_error);
             consumed = true;
         } else if(event.event == PicopassWorkerEventLoclassFileError) {
             scene_manager_set_scene_state(picopass->scene_manager, PicopassSceneLoclass, 255);


### PR DESCRIPTION
# What's new

- Added haptics to picopass

# Verification 

- Run loclass
- Place against reader with standard key
- Experience "error" haptic
- Place against reader with elite key
- Experience single vibration for each response (they can feel almost like one long (~half second) vibration.  Experience quick pause and final vibration (in reality a double vibration) when all 18 are collected.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
