### PR TITLE
Picopass: populate key change input with first key of user dictionary

### DIFF
--- a/picopass/scenes/picopass_scene_key_menu.c
+++ b/picopass/scenes/picopass_scene_key_menu.c
@@ -91,9 +91,16 @@ bool picopass_scene_key_menu_on_event(void* context, SceneManagerEvent event) {
             scene_manager_next_scene(picopass->scene_manager, PicopassSceneWriteKey);
             consumed = true;
         } else if(event.event == SubmenuIndexWriteCustom) {
+            // If user dictionary, prepopulate with the first key
+            if(iclass_elite_dict_check_presence(IclassEliteDictTypeUser)) {
+                IclassEliteDict* dict = iclass_elite_dict_alloc(IclassEliteDictTypeUser);
+                iclass_elite_dict_get_next_key(dict, picopass->byte_input_store);
+                iclass_elite_dict_free(dict);
+            }
+
             scene_manager_set_scene_state(
                 picopass->scene_manager, PicopassSceneKeyMenu, SubmenuIndexWriteCustom);
-            // Key and elite_kdf = true are both set in key_input scene
+            // Key and elite_kdf = true are both set in key_input scene after the value is input
             scene_manager_next_scene(picopass->scene_manager, PicopassSceneKeyInput);
             consumed = true;
         }


### PR DESCRIPTION
# What's new

- To make changing keys easier, populate the manual key entry with the first key of the user's dictionary

![Screenshot-20230924-193306](https://github.com/flipperdevices/flipperzero-good-faps/assets/115752/5667b3bc-1725-44a6-b5f6-16409ad23c9f)


# Verification 

- Upload a file to `picopass/assets/iclass_elite_dict_user.txt`
- Read a card
- Select More
- Select Change Key
- Select Write Elite
- See the first key of the user dictionary populated in input box

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
