### PR TITLE
add acurite-986 protocol

### DIFF
--- a/weather_station/.catalog/README.md
+++ b/weather_station/.catalog/README.md
@@ -12,6 +12,7 @@ GT-WT03
 Acurite 592TXR
 Acurite-606TX
 Acurite-606TXC
+Acurite-986
 LaCrosse_TX
 TX141THBv2
 Oregon-v1

--- a/weather_station/.catalog/changelog.md
+++ b/weather_station/.catalog/changelog.md
@@ -1,0 +1,7 @@
+## 1.2
+ - Add protocol Acurite-986
+ - Functions for working with delays have been changed
+## 1.1
+ - Add protocol Auriol_AHFL
+## 1.0
+ - Initial release

--- a/weather_station/application.fam
+++ b/weather_station/application.fam
@@ -7,7 +7,7 @@ App(
     requires=["gui"],
     stack_size=4 * 1024,
     fap_description="Receive weather data from a wide range of supported Sub-1GHz remote sensor",
-    fap_version="1.1",
+    fap_version="1.2",
     fap_icon="weather_station_10px.png",
     fap_category="Sub-GHz",
     fap_icon_assets="images",

--- a/weather_station/helpers/weather_station_types.h
+++ b/weather_station/helpers/weather_station_types.h
@@ -3,7 +3,7 @@
 #include <furi.h>
 #include <furi_hal.h>
 
-#define WS_VERSION_APP "1.1"
+#define WS_VERSION_APP "1.2"
 #define WS_DEVELOPED "SkorP"
 #define WS_GITHUB "https://github.com/flipperdevices/flipperzero-good-faps"
 

--- a/weather_station/protocols/acurite_986.c
+++ b/weather_station/protocols/acurite_986.c
@@ -8,12 +8,13 @@
  *
  *     0110 0100 | 1010 1011 | 0110 0010 | 0000 0000 | 0111 0110
  *     tttt tttt | IIII IIII | iiii iiii | nbuu uuuu | cccc cccc
+ * - t: temperature in °F
  * - I: identification (high byte)
  * - i: identification (low byte)
+ * - n: sensor number
+ * - b: battery low flag to indicate low battery voltage
+ * - u: unknown
  * - c: CRC (CRC-8 poly 0x07, little-endian)
- * - u: unknown;
- * - b: battery low; flag to indicate low battery voltage
- * - t: Temperature; in °F
  *
  *  bits are sent and shown above LSB first
  *  identification changes on battery switch

--- a/weather_station/protocols/acurite_986.c
+++ b/weather_station/protocols/acurite_986.c
@@ -1,0 +1,270 @@
+#include "acurite_986.h"
+
+#define TAG "WSProtocolAcurite_986"
+
+/*
+ * Help
+ * https://github.com/merbanan/rtl_433/blob/5bef4e43133ac4c0e2d18d36f87c52b4f9458453/src/devices/acurite.c#L1644
+ *
+ *     0110 0100 | 1010 1011 | 0110 0010 | 0000 0000 | 0111 0110
+ *     tttt tttt | IIII IIII | iiii iiii | nbuu uuuu | cccc cccc
+ * - I: identification (high byte)
+ * - i: identification (low byte)
+ * - c: CRC (CRC-8 poly 0x07, little-endian)
+ * - u: unknown;
+ * - b: battery low; flag to indicate low battery voltage
+ * - t: Temperature; in °F
+ *
+ *  bits are sent and shown above LSB first
+ *  identification changes on battery switch
+ */
+
+static const SubGhzBlockConst ws_protocol_acurite_986_const = {
+    .te_short = 800,
+    .te_long = 1750,
+    .te_delta = 50,
+    .min_count_bit_for_found = 40,
+};
+
+struct WSProtocolDecoderAcurite_986 {
+    SubGhzProtocolDecoderBase base;
+
+    SubGhzBlockDecoder decoder;
+    WSBlockGeneric generic;
+};
+
+struct WSProtocolEncoderAcurite_986 {
+    SubGhzProtocolEncoderBase base;
+
+    SubGhzProtocolBlockEncoder encoder;
+    WSBlockGeneric generic;
+};
+
+typedef enum {
+    Acurite_986DecoderStepReset = 0,
+    Acurite_986DecoderStepSync1,
+    Acurite_986DecoderStepSync2,
+    Acurite_986DecoderStepSync3,
+    Acurite_986DecoderStepSaveDuration,
+    Acurite_986DecoderStepCheckDuration,
+} Acurite_986DecoderStep;
+
+const SubGhzProtocolDecoder ws_protocol_acurite_986_decoder = {
+    .alloc = ws_protocol_decoder_acurite_986_alloc,
+    .free = ws_protocol_decoder_acurite_986_free,
+
+    .feed = ws_protocol_decoder_acurite_986_feed,
+    .reset = ws_protocol_decoder_acurite_986_reset,
+
+    .get_hash_data = ws_protocol_decoder_acurite_986_get_hash_data,
+    .serialize = ws_protocol_decoder_acurite_986_serialize,
+    .deserialize = ws_protocol_decoder_acurite_986_deserialize,
+    .get_string = ws_protocol_decoder_acurite_986_get_string,
+};
+
+const SubGhzProtocolEncoder ws_protocol_acurite_986_encoder = {
+    .alloc = NULL,
+    .free = NULL,
+
+    .deserialize = NULL,
+    .stop = NULL,
+    .yield = NULL,
+};
+
+const SubGhzProtocol ws_protocol_acurite_986 = {
+    .name = WS_PROTOCOL_ACURITE_986_NAME,
+    .type = SubGhzProtocolWeatherStation,
+    .flag = SubGhzProtocolFlag_433 | SubGhzProtocolFlag_315 | SubGhzProtocolFlag_868 |
+            SubGhzProtocolFlag_AM | SubGhzProtocolFlag_Decodable,
+
+    .decoder = &ws_protocol_acurite_986_decoder,
+    .encoder = &ws_protocol_acurite_986_encoder,
+};
+
+void* ws_protocol_decoder_acurite_986_alloc(SubGhzEnvironment* environment) {
+    UNUSED(environment);
+    WSProtocolDecoderAcurite_986* instance = malloc(sizeof(WSProtocolDecoderAcurite_986));
+    instance->base.protocol = &ws_protocol_acurite_986;
+    instance->generic.protocol_name = instance->base.protocol->name;
+    return instance;
+}
+
+void ws_protocol_decoder_acurite_986_free(void* context) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+    free(instance);
+}
+
+void ws_protocol_decoder_acurite_986_reset(void* context) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+    instance->decoder.parser_step = Acurite_986DecoderStepReset;
+}
+
+static bool ws_protocol_acurite_986_check(WSProtocolDecoderAcurite_986* instance) {
+    if(!instance->decoder.decode_data) return false;
+    uint8_t msg[] = {
+    instance->decoder.decode_data >> 32,
+    instance->decoder.decode_data >> 24,
+    instance->decoder.decode_data >> 16,
+    instance->decoder.decode_data >> 8 };
+
+    uint8_t crc = subghz_protocol_blocks_crc8(msg, 4, 0x07, 0x00);
+    return (crc == (instance->decoder.decode_data & 0xFF));
+}
+
+/**
+ * Analysis of received data
+ * @param instance Pointer to a WSBlockGeneric* instance
+ */
+static void ws_protocol_acurite_986_remote_controller(WSBlockGeneric* instance) {
+    int temp;
+
+    instance->id = subghz_protocol_blocks_reverse_key(instance->data >> 24, 8);
+    instance->id = (instance->id << 8) | subghz_protocol_blocks_reverse_key(instance->data >> 16, 8);
+    instance->battery_low = (instance->data >> 14) & 1;
+    instance->channel = ((instance->data >> 15) & 1) + 1;
+
+    temp = subghz_protocol_blocks_reverse_key(instance->data >> 32, 8);
+    if(temp & 0x80) {
+        temp = -(temp & 0x7F);
+    }
+    instance->temp = locale_fahrenheit_to_celsius((float)temp);
+    instance->btn = WS_NO_BTN;
+    instance->humidity = WS_NO_HUMIDITY;
+}
+
+void ws_protocol_decoder_acurite_986_feed(void* context, bool level, uint32_t duration) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+
+    switch(instance->decoder.parser_step) {
+    case Acurite_986DecoderStepReset:
+        if((!level) && (DURATION_DIFF(duration, ws_protocol_acurite_986_const.te_long) <
+                        ws_protocol_acurite_986_const.te_delta * 15)) {
+            //Found 1st sync bit
+            instance->decoder.parser_step = Acurite_986DecoderStepSync1;
+            instance->decoder.decode_data = 0;
+            instance->decoder.decode_count_bit = 0;
+        }
+        break;
+
+    case Acurite_986DecoderStepSync1:
+        if(DURATION_DIFF(duration, ws_protocol_acurite_986_const.te_long) <
+                         ws_protocol_acurite_986_const.te_delta * 15) {
+            if(!level) {
+                instance->decoder.parser_step = Acurite_986DecoderStepSync2;
+            }
+        } else {
+            instance->decoder.parser_step = Acurite_986DecoderStepReset;
+        }
+        break;
+
+    case Acurite_986DecoderStepSync2:
+        if(DURATION_DIFF(duration, ws_protocol_acurite_986_const.te_long) <
+                         ws_protocol_acurite_986_const.te_delta * 15) {
+            if(!level) {
+                instance->decoder.parser_step = Acurite_986DecoderStepSync3;
+            }
+        } else {
+            instance->decoder.parser_step = Acurite_986DecoderStepReset;
+        }
+        break;
+
+    case Acurite_986DecoderStepSync3:
+        if(DURATION_DIFF(duration, ws_protocol_acurite_986_const.te_long) <
+                         ws_protocol_acurite_986_const.te_delta * 15) {
+            if(!level) {
+                instance->decoder.parser_step = Acurite_986DecoderStepSaveDuration;
+            }
+        } else {
+            instance->decoder.parser_step = Acurite_986DecoderStepReset;
+        }
+        break;
+
+    case Acurite_986DecoderStepSaveDuration:
+        if(level) {
+            instance->decoder.te_last = duration;
+            instance->decoder.parser_step = Acurite_986DecoderStepCheckDuration;
+        } else {
+            instance->decoder.parser_step = Acurite_986DecoderStepReset;
+        }
+        break;
+
+    case Acurite_986DecoderStepCheckDuration:
+        if(!level) {
+            if(DURATION_DIFF(duration, ws_protocol_acurite_986_const.te_short) <
+                             ws_protocol_acurite_986_const.te_delta * 10) {
+                if(duration < ws_protocol_acurite_986_const.te_short) {
+                    subghz_protocol_blocks_add_bit(&instance->decoder, 0);
+                    instance->decoder.parser_step = Acurite_986DecoderStepSaveDuration;
+                } else {
+                    subghz_protocol_blocks_add_bit(&instance->decoder, 1);
+                    instance->decoder.parser_step = Acurite_986DecoderStepSaveDuration;
+                }
+            } else {
+                //Found syncPostfix
+                instance->decoder.parser_step = Acurite_986DecoderStepReset;
+                if((instance->decoder.decode_count_bit == ws_protocol_acurite_986_const.min_count_bit_for_found) &&
+                    ws_protocol_acurite_986_check(instance)) {
+                    instance->generic.data = instance->decoder.decode_data;
+                    instance->generic.data_count_bit = instance->decoder.decode_count_bit;
+                    ws_protocol_acurite_986_remote_controller(&instance->generic);
+                    if(instance->base.callback)
+                        instance->base.callback(&instance->base, instance->base.context);
+                }
+                instance->decoder.decode_data = 0;
+                instance->decoder.decode_count_bit = 0;
+            }
+        } else {
+            instance->decoder.parser_step = Acurite_986DecoderStepReset;
+        }
+        break;
+    }
+}
+
+uint8_t ws_protocol_decoder_acurite_986_get_hash_data(void* context) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+    return subghz_protocol_blocks_get_hash_data(
+        &instance->decoder, (instance->decoder.decode_count_bit / 8) + 1);
+}
+
+SubGhzProtocolStatus ws_protocol_decoder_acurite_986_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+    return ws_block_generic_serialize(&instance->generic, flipper_format, preset);
+}
+
+SubGhzProtocolStatus
+    ws_protocol_decoder_acurite_986_deserialize(void* context, FlipperFormat* flipper_format) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+    return ws_block_generic_deserialize_check_count_bit(
+        &instance->generic,
+        flipper_format,
+        ws_protocol_acurite_986_const.min_count_bit_for_found);
+}
+
+void ws_protocol_decoder_acurite_986_get_string(void* context, FuriString* output) {
+    furi_assert(context);
+    WSProtocolDecoderAcurite_986* instance = context;
+    furi_string_printf(
+        output,
+        "%s %dbit\r\n"
+        "Key:0x%lX%08lX\r\n"
+        "Sn:0x%lX Ch:%d  Bat:%d\r\n"
+        "Temp:%3.1f C Hum:%d%%",
+        instance->generic.protocol_name,
+        instance->generic.data_count_bit,
+        (uint32_t)(instance->generic.data >> 32),
+        (uint32_t)(instance->generic.data),
+        instance->generic.id,
+        instance->generic.channel,
+        instance->generic.battery_low,
+        (double)instance->generic.temp,
+        instance->generic.humidity);
+}

--- a/weather_station/protocols/acurite_986.h
+++ b/weather_station/protocols/acurite_986.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <lib/subghz/protocols/base.h>
+
+#include <lib/subghz/blocks/const.h>
+#include <lib/subghz/blocks/decoder.h>
+#include <lib/subghz/blocks/encoder.h>
+#include "ws_generic.h"
+#include <lib/subghz/blocks/math.h>
+
+#define WS_PROTOCOL_ACURITE_986_NAME "Acurite-986"
+
+typedef struct WSProtocolDecoderAcurite_986 WSProtocolDecoderAcurite_986;
+typedef struct WSProtocolEncoderAcurite_986 WSProtocolEncoderAcurite_986;
+
+extern const SubGhzProtocolDecoder ws_protocol_acurite_986_decoder;
+extern const SubGhzProtocolEncoder ws_protocol_acurite_986_encoder;
+extern const SubGhzProtocol ws_protocol_acurite_986;
+
+/**
+ * Allocate WSProtocolDecoderAcurite_986.
+ * @param environment Pointer to a SubGhzEnvironment instance
+ * @return WSProtocolDecoderAcurite_986* pointer to a WSProtocolDecoderAcurite_986 instance
+ */
+void* ws_protocol_decoder_acurite_986_alloc(SubGhzEnvironment* environment);
+
+/**
+ * Free WSProtocolDecoderAcurite_986.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ */
+void ws_protocol_decoder_acurite_986_free(void* context);
+
+/**
+ * Reset decoder WSProtocolDecoderAcurite_986.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ */
+void ws_protocol_decoder_acurite_986_reset(void* context);
+
+/**
+ * Parse a raw sequence of levels and durations received from the air.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ * @param level Signal level true-high false-low
+ * @param duration Duration of this level in, us
+ */
+void ws_protocol_decoder_acurite_986_feed(void* context, bool level, uint32_t duration);
+
+/**
+ * Getting the hash sum of the last randomly received parcel.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ * @return hash Hash sum
+ */
+uint8_t ws_protocol_decoder_acurite_986_get_hash_data(void* context);
+
+/**
+ * Serialize data WSProtocolDecoderAcurite_986.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @param preset The modulation on which the signal was received, SubGhzRadioPreset
+ * @return status
+ */
+SubGhzProtocolStatus ws_protocol_decoder_acurite_986_serialize(
+    void* context,
+    FlipperFormat* flipper_format,
+    SubGhzRadioPreset* preset);
+
+/**
+ * Deserialize data WSProtocolDecoderAcurite_986.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ * @param flipper_format Pointer to a FlipperFormat instance
+ * @return status
+ */
+SubGhzProtocolStatus
+    ws_protocol_decoder_acurite_986_deserialize(void* context, FlipperFormat* flipper_format);
+
+/**
+ * Getting a textual representation of the received data.
+ * @param context Pointer to a WSProtocolDecoderAcurite_986 instance
+ * @param output Resulting text
+ */
+void ws_protocol_decoder_acurite_986_get_string(void* context, FuriString* output);

--- a/weather_station/protocols/protocol_items.c
+++ b/weather_station/protocols/protocol_items.c
@@ -8,6 +8,7 @@ const SubGhzProtocol* weather_station_protocol_registry_items[] = {
     &ws_protocol_gt_wt_03,
     &ws_protocol_acurite_606tx,
     &ws_protocol_acurite_609txc,
+    &ws_protocol_acurite_986,
     &ws_protocol_lacrosse_tx,
     &ws_protocol_lacrosse_tx141thbv2,
     &ws_protocol_oregon2,

--- a/weather_station/protocols/protocol_items.h
+++ b/weather_station/protocols/protocol_items.h
@@ -8,6 +8,7 @@
 #include "gt_wt_03.h"
 #include "acurite_606tx.h"
 #include "acurite_609txc.h"
+#include "acurite_986.h"
 #include "lacrosse_tx.h"
 #include "lacrosse_tx141thbv2.h"
 #include "oregon2.h"

--- a/weather_station/views/weather_station_receiver.c
+++ b/weather_station/views/weather_station_receiver.c
@@ -88,7 +88,7 @@ void ws_view_receiver_set_lock(WSReceiver* ws_receiver, WSLock lock) {
             WSReceiverModel * model,
             { model->bar_show = WSReceiverBarShowLock; },
             true);
-        furi_timer_start(ws_receiver->timer, pdMS_TO_TICKS(1000));
+        furi_timer_start(ws_receiver->timer, 1000);
     } else {
         with_view_model(
             ws_receiver->view,
@@ -293,7 +293,7 @@ bool ws_view_receiver_input(InputEvent* event, void* context) {
             { model->bar_show = WSReceiverBarShowToUnlockPress; },
             true);
         if(ws_receiver->lock_count == 0) {
-            furi_timer_start(ws_receiver->timer, pdMS_TO_TICKS(1000));
+            furi_timer_start(ws_receiver->timer, 1000);
         }
         if(event->key == InputKeyBack && event->type == InputTypeShort) {
             ws_receiver->lock_count++;
@@ -306,7 +306,7 @@ bool ws_view_receiver_input(InputEvent* event, void* context) {
                 { model->bar_show = WSReceiverBarShowUnlock; },
                 true);
             ws_receiver->lock = WSLockOff;
-            furi_timer_start(ws_receiver->timer, pdMS_TO_TICKS(650));
+            furi_timer_start(ws_receiver->timer, 650);
         }
 
         return true;


### PR DESCRIPTION
# What's new

- Support for decoding the Acurite-986 sensor in the WeatherStation App

# Verification 

- Three sample transmissions are attached as [transmissions.zip](https://github.com/flipperdevices/flipperzero-good-faps/files/13312354/transmissions.zip)
  - S1-38F.sub represents Sensor 1, 38°F, good battery
  - S2-39F.sub represents Sensor 2, 39°F, good battery
  - S1-minus2Fbatt.sub represents Sensor 1, -2°F, low battery

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix