### PR TITLE
Add XT25F128B details to the SPI memory manager app

### DIFF
--- a/spi_mem_manager/.catalog/changelog.md
+++ b/spi_mem_manager/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.2
+   Added support for the XT25F128B flash chip
 ## 1.1
  - New random filename API
 ## 1.0

--- a/spi_mem_manager/application.fam
+++ b/spi_mem_manager/application.fam
@@ -6,7 +6,7 @@ App(
     requires=["gui"],
     stack_size=1 * 2048,
     fap_description="Application for reading and writing 25-series SPI memory chips",
-    fap_version="1.1",
+    fap_version="1.2",
     fap_icon="images/Dip8_10px.png",
     fap_category="GPIO",
     fap_icon_assets="images",

--- a/spi_mem_manager/lib/spi/spi_mem_chip.c
+++ b/spi_mem_manager/lib/spi/spi_mem_chip.c
@@ -38,6 +38,7 @@ const SPIMemChipVendorName spi_mem_chip_vendor_names[] = {
     {"Fudan", SPIMemChipVendorFudan},
     {"Genitop", SPIMemChipVendorGenitop},
     {"Paragon", SPIMemChipVendorParagon},
+    {"XTX", SPIMemChipVendorXTX},
     {"Unknown", SPIMemChipVendorUnknown}};
 
 static const char* spi_mem_chip_search_vendor_name(SPIMemChipVendor vendor_enum) {

--- a/spi_mem_manager/lib/spi/spi_mem_chip_arr.c
+++ b/spi_mem_manager/lib/spi/spi_mem_chip_arr.c
@@ -1396,4 +1396,5 @@ const SPIMemChip SPIMemChips[] = {
     {0xA1, 0x40, 0x13, "FM25Q04A", 524288, 256, SPIMemChipVendorFudan, SPIMemChipWriteModePage},
     {0xA1, 0x40, 0x16, "FM25Q32", 4194304, 256, SPIMemChipVendorFudan, SPIMemChipWriteModePage},
     {0xE0, 0x40, 0x14, "GT25Q80A", 1048576, 256, SPIMemChipVendorGenitop, SPIMemChipWriteModePage},
-    {0xE0, 0x40, 0x13, "PN25F04A", 524288, 256, SPIMemChipVendorParagon, SPIMemChipWriteModePage}};
+    {0xE0, 0x40, 0x13, "PN25F04A", 524288, 256, SPIMemChipVendorParagon, SPIMemChipWriteModePage},
+    {0x0B, 0x40, 0x18, "XT25F128B", 16777216, 256, SPIMemChipVendorXTX, SPIMemChipWriteModePage}};

--- a/spi_mem_manager/lib/spi/spi_mem_chip_i.h
+++ b/spi_mem_manager/lib/spi/spi_mem_chip_i.h
@@ -41,7 +41,8 @@ typedef enum {
     SPIMemChipVendorFremont,
     SPIMemChipVendorFudan,
     SPIMemChipVendorGenitop,
-    SPIMemChipVendorParagon
+    SPIMemChipVendorParagon,
+    SPIMemChipVendorXTX
 } SPIMemChipVendor;
 
 typedef enum {


### PR DESCRIPTION
This change adds a definition for a flash chip produced by XTX Technology Inc.

Datasheet:
https://datasheet.lcsc.com/lcsc/2101041805_XTX-XT25W128BWOIGT_C966949.pdf

- Vendor ID: 0x0B
- Type ID: 0x40
- Capacity ID: 0x18
- Page size: 256 bytes
- Total size: 128 Mib = (128 / 8) MiB = 16 MiB = 16777216 bytes

Tested on PineCube which has this kind of memory:
https://wikidevi.wi-cat.ru/PineCube

# What's new

- Added a flash memory definition for XT25F128B.

# Verification 

The unpatched version just shows discovered ids:
![image](https://github.com/flipperdevices/flipperzero-good-faps/assets/12861810/82a3df3e-ced3-4922-bbeb-154ce1efec7a)

After the fix the device discovers the chip correctly:
![image](https://github.com/flipperdevices/flipperzero-good-faps/assets/12861810/67042451-6850-44b9-a83b-63c195bab984)

- Apply the patch to your tree
- Run `ufbt && ufbt launch` while a Flipper device is connected via USB to your host
- Try connecting to the XT25W128B chip via SPI: it should get discovered properly and doing IO operations should work.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
