### PR TITLE
Picopass: Create folder before loclass

### DIFF
--- a/picopass/loclass_writer.c
+++ b/picopass/loclass_writer.c
@@ -16,6 +16,7 @@ LoclassWriter* loclass_writer_alloc() {
     LoclassWriter* instance = malloc(sizeof(LoclassWriter));
     Storage* storage = furi_record_open(RECORD_STORAGE);
     instance->file_stream = buffered_file_stream_alloc(storage);
+    storage_simply_mkdir(storage, STORAGE_APP_DATA_PATH_PREFIX);
     if(!buffered_file_stream_open(
            instance->file_stream, LOCLASS_LOGS_PATH, FSAM_WRITE, FSOM_OPEN_APPEND)) {
         buffered_file_stream_close(instance->file_stream);


### PR DESCRIPTION
# What's new

- Creates picopass folder before localss runs

Note: https://github.com/flipperdevices/flipperzero-firmware/blob/f9101d80840b4b7ef7146e41bba99aac881bbfca/applications/services/storage/filesystem_api_defines.h#L20 makes me think I shouldn't need to do this, but I do, or there is an error.

# Verification 

- Remove picopass folder
- Run picopass
- Run loclass
- Loclass runs and there is no error
- See folder is created

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
