### PR TITLE
Picopass save as seader

### DIFF
--- a/picopass/.catalog/changelog.md
+++ b/picopass/.catalog/changelog.md
@@ -1,3 +1,8 @@
+## 1.9
+ - Fix bug (#77) with loclass
+ - Better loclass notes
+ - Read card using nr-mac
+ - Save as Seader format
 ## 1.8
  - Minimal changes for recent API updates
 ## 1.7

--- a/picopass/application.fam
+++ b/picopass/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="App to communicate with NFC tags using the PicoPass(iClass) format",
-    fap_version="1.8",
+    fap_version="1.9",
     fap_icon="125_10px.png",
     fap_category="NFC",
     fap_libs=["mbedtls"],

--- a/picopass/picopass_device.h
+++ b/picopass/picopass_device.h
@@ -70,6 +70,7 @@ typedef enum {
 typedef enum {
     PicopassDeviceSaveFormatHF,
     PicopassDeviceSaveFormatLF,
+    PicopassDeviceSaveFormatSeader,
 } PicopassDeviceSaveFormat;
 
 typedef enum {

--- a/picopass/protocol/picopass_poller.c
+++ b/picopass/protocol/picopass_poller.c
@@ -286,8 +286,14 @@ NfcCommand picopass_poller_nr_mac_auth(PicopassPoller* instance) {
                 picopass_poller_prepare_read(instance);
                 instance->state = PicopassPollerStateReadBlock;
                 // Set to non-zero keys to allow emulation
-                memset(instance->data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xff, PICOPASS_BLOCK_LEN);
-                memset(instance->data->AA1[PICOPASS_SECURE_KC_BLOCK_INDEX].data, 0xff, PICOPASS_BLOCK_LEN);
+                memset(
+                    instance->data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data,
+                    0xff,
+                    PICOPASS_BLOCK_LEN);
+                memset(
+                    instance->data->AA1[PICOPASS_SECURE_KC_BLOCK_INDEX].data,
+                    0xff,
+                    PICOPASS_BLOCK_LEN);
             }
         }
 

--- a/picopass/scenes/picopass_scene_card_menu.c
+++ b/picopass/scenes/picopass_scene_card_menu.c
@@ -3,6 +3,7 @@
 enum SubmenuIndex {
     SubmenuIndexSave,
     SubmenuIndexSaveAsLF,
+    SubmenuIndexSaveAsSeader,
     SubmenuIndexChangeKey,
     SubmenuIndexWrite,
     SubmenuIndexEmulate,
@@ -31,7 +32,12 @@ void picopass_scene_card_menu_on_enter(void* context) {
                 SubmenuIndexSave,
                 picopass_scene_card_menu_submenu_callback,
                 picopass);
-
+            submenu_add_item(
+                submenu,
+                "Save in Seader fmt",
+                SubmenuIndexSaveAsSeader,
+                picopass_scene_card_menu_submenu_callback,
+                picopass);
         } else {
             submenu_add_item(
                 submenu,
@@ -49,7 +55,14 @@ void picopass_scene_card_menu_on_enter(void* context) {
             SubmenuIndexSaveAsLF,
             picopass_scene_card_menu_submenu_callback,
             picopass);
-
+        if(pacs->sio) { // SR
+            submenu_add_item(
+                submenu,
+                "Save in Seader fmt",
+                SubmenuIndexSaveAsSeader,
+                picopass_scene_card_menu_submenu_callback,
+                picopass);
+        }
         submenu_add_item(
             submenu,
             "Write",
@@ -93,6 +106,12 @@ bool picopass_scene_card_menu_on_event(void* context, SceneManagerEvent event) {
                 picopass->scene_manager, PicopassSceneCardMenu, SubmenuIndexSave);
             scene_manager_next_scene(picopass->scene_manager, PicopassSceneSaveName);
             picopass->dev->format = PicopassDeviceSaveFormatHF;
+            consumed = true;
+        } else if(event.event == SubmenuIndexSaveAsSeader) {
+            scene_manager_set_scene_state(
+                picopass->scene_manager, PicopassSceneCardMenu, event.event);
+            scene_manager_next_scene(picopass->scene_manager, PicopassSceneSaveName);
+            picopass->dev->format = PicopassDeviceSaveFormatSeader;
             consumed = true;
         } else if(event.event == SubmenuIndexSaveAsLF) {
             scene_manager_set_scene_state(


### PR DESCRIPTION
# What's new

- Allows saving the SIO as Seader's agnostic format

# Verification 

- Read a card with an SIO (SE, SR).  
- Select the "Save as Seader fmt" 
- Name file
- Confirm file is in apps_data/seader/<name>.credential

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
