### PR TITLE
PicoPass: Fix name buffer size issues

### DIFF
--- a/picopass/picopass_device.c
+++ b/picopass/picopass_device.c
@@ -31,7 +31,7 @@ PicopassDevice* picopass_device_alloc() {
 void picopass_device_set_name(PicopassDevice* dev, const char* name) {
     furi_assert(dev);
 
-    strlcpy(dev->dev_name, name, PICOPASS_DEV_NAME_MAX_LEN);
+    strlcpy(dev->dev_name, name, sizeof(dev->dev_name));
 }
 
 // For use with Seader's virtual card processing.
@@ -343,7 +343,7 @@ bool picopass_file_select(PicopassDevice* dev) {
         FuriString* filename;
         filename = furi_string_alloc();
         path_extract_filename(dev->load_path, filename, true);
-        strncpy(dev->dev_name, furi_string_get_cstr(filename), PICOPASS_DEV_NAME_MAX_LEN);
+        strlcpy(dev->dev_name, furi_string_get_cstr(filename), sizeof(dev->dev_name));
         res = picopass_device_load_data(dev, dev->load_path, true);
         if(res) {
             picopass_device_set_name(dev, dev->dev_name);

--- a/picopass/picopass_device.h
+++ b/picopass/picopass_device.h
@@ -19,7 +19,7 @@
 #endif
 #define LOCLASS_MACS_TO_COLLECT (LOCLASS_NUM_CSNS * LOCLASS_NUM_PER_CSN)
 
-#define PICOPASS_DEV_NAME_MAX_LEN 22
+#define PICOPASS_DEV_NAME_MAX_LEN 129
 #define PICOPASS_READER_DATA_MAX_SIZE 64
 #define PICOPASS_MAX_APP_LIMIT 32
 
@@ -119,7 +119,7 @@ typedef struct {
     Storage* storage;
     DialogsApp* dialogs;
     PicopassDeviceData dev_data;
-    char dev_name[PICOPASS_DEV_NAME_MAX_LEN + 1];
+    char dev_name[PICOPASS_DEV_NAME_MAX_LEN];
     FuriString* load_path;
     PicopassDeviceSaveFormat format;
     PicopassLoadingCallback loading_cb;

--- a/picopass/picopass_i.h
+++ b/picopass/picopass_i.h
@@ -33,7 +33,7 @@
 #include "protocol/picopass_poller.h"
 #include "protocol/picopass_listener.h"
 
-#define PICOPASS_TEXT_STORE_SIZE 128
+#define PICOPASS_TEXT_STORE_SIZE 129
 
 #define PICOPASS_ICLASS_ELITE_DICT_FLIPPER_NAME APP_ASSETS_PATH("iclass_elite_dict.txt")
 #define PICOPASS_ICLASS_STANDARD_DICT_FLIPPER_NAME APP_ASSETS_PATH("iclass_standard_dict.txt")
@@ -90,7 +90,7 @@ struct Picopass {
     PicopassListener* listener;
     NfcDict* dict;
 
-    char text_store[PICOPASS_TEXT_STORE_SIZE + 1];
+    char text_store[PICOPASS_TEXT_STORE_SIZE];
     FuriString* text_box_store;
     uint8_t byte_input_store[PICOPASS_BLOCK_LEN];
 

--- a/picopass/scenes/picopass_scene_delete.c
+++ b/picopass/scenes/picopass_scene_delete.c
@@ -11,7 +11,7 @@ void picopass_scene_delete_on_enter(void* context) {
     Picopass* picopass = context;
 
     // Setup Custom Widget view
-    char temp_str[64];
+    char temp_str[141];
     snprintf(temp_str, sizeof(temp_str), "\e#Delete %s?\e#", picopass->dev->dev_name);
     widget_add_text_box_element(
         picopass->widget, 0, 0, 128, 23, AlignCenter, AlignCenter, temp_str, false);

--- a/picopass/scenes/picopass_scene_save_name.c
+++ b/picopass/scenes/picopass_scene_save_name.c
@@ -28,7 +28,7 @@ void picopass_scene_save_name_on_enter(void* context) {
         picopass_scene_save_name_text_input_callback,
         picopass,
         picopass->text_store,
-        PICOPASS_DEV_NAME_MAX_LEN,
+        sizeof(picopass->text_store),
         dev_name_empty);
 
     FuriString* folder_path;


### PR DESCRIPTION
# What's new

- Conflict between text input buffer size and device name buffer size can cause crashes on edge cases
- Text input and strlcpy() account for the null terminator, no need for +1 on buffer length, can just use sizeof()
- Also replaced unsafe strncpy() usage with strlcpy() which accounts for null terminator
- More info [here](https://github.com/Flipper-XFW/Xtreme-Firmware/issues/487#issuecomment-1853100082)
- I dont have PicoPass cards to confirm if the issue is fixed or if it causes other oddities, but from code alone this seems like the necessary fix

# Verification 

- Can save picopass cards with names longer than 23 characters without crashing

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
