### PR TITLE
Added XM25QH64C and XM25QH128A support for spi mem manger app.

### DIFF
--- a/spi_mem_manager/.catalog/changelog.md
+++ b/spi_mem_manager/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.3
+   XM25QH64C and XM25QH128A flash chip support added
 ## 1.2
    Added support for the XT25F128B flash chip
 ## 1.1

--- a/spi_mem_manager/application.fam
+++ b/spi_mem_manager/application.fam
@@ -6,7 +6,7 @@ App(
     requires=["gui"],
     stack_size=1 * 2048,
     fap_description="Application for reading and writing 25-series SPI memory chips",
-    fap_version="1.2",
+    fap_version="1.3",
     fap_icon="images/Dip8_10px.png",
     fap_category="GPIO",
     fap_icon_assets="images",

--- a/spi_mem_manager/lib/spi/spi_mem_chip.c
+++ b/spi_mem_manager/lib/spi/spi_mem_chip.c
@@ -39,6 +39,7 @@ const SPIMemChipVendorName spi_mem_chip_vendor_names[] = {
     {"Genitop", SPIMemChipVendorGenitop},
     {"Paragon", SPIMemChipVendorParagon},
     {"XTX", SPIMemChipVendorXTX},
+    {"XMC", SPIMemChipVendorXMC},
     {"Unknown", SPIMemChipVendorUnknown}};
 
 static const char* spi_mem_chip_search_vendor_name(SPIMemChipVendor vendor_enum) {

--- a/spi_mem_manager/lib/spi/spi_mem_chip_arr.c
+++ b/spi_mem_manager/lib/spi/spi_mem_chip_arr.c
@@ -1399,4 +1399,4 @@ const SPIMemChip SPIMemChips[] = {
     {0xE0, 0x40, 0x13, "PN25F04A", 524288, 256, SPIMemChipVendorParagon, SPIMemChipWriteModePage},
     {0x0B, 0x40, 0x18, "XT25F128B", 16777216, 256, SPIMemChipVendorXTX, SPIMemChipWriteModePage},
     {0x20, 0x70, 0x17, "XM25QH64C", 8388608, 256, SPIMemChipVendorXMC, SPIMemChipWriteModePage},
-    {0x20, 0x70, 0x18, "XM25QH128A", 16776960, 256, SPIMemChipVendorXMC, SPIMemChipWriteModePage}};
+    {0x20, 0x70, 0x18, "XM25QH128A", 16777216, 256, SPIMemChipVendorXMC, SPIMemChipWriteModePage}};

--- a/spi_mem_manager/lib/spi/spi_mem_chip_arr.c
+++ b/spi_mem_manager/lib/spi/spi_mem_chip_arr.c
@@ -1397,4 +1397,6 @@ const SPIMemChip SPIMemChips[] = {
     {0xA1, 0x40, 0x16, "FM25Q32", 4194304, 256, SPIMemChipVendorFudan, SPIMemChipWriteModePage},
     {0xE0, 0x40, 0x14, "GT25Q80A", 1048576, 256, SPIMemChipVendorGenitop, SPIMemChipWriteModePage},
     {0xE0, 0x40, 0x13, "PN25F04A", 524288, 256, SPIMemChipVendorParagon, SPIMemChipWriteModePage},
-    {0x0B, 0x40, 0x18, "XT25F128B", 16777216, 256, SPIMemChipVendorXTX, SPIMemChipWriteModePage}};
+    {0x0B, 0x40, 0x18, "XT25F128B", 16777216, 256, SPIMemChipVendorXTX, SPIMemChipWriteModePage},
+    {0x20, 0x70, 0x17, "XM25QH64C", 8388608, 256, SPIMemChipVendorXMC, SPIMemChipWriteModePage},
+    {0x20, 0x70, 0x18, "XM25QH128A", 16776960, 256, SPIMemChipVendorXMC, SPIMemChipWriteModePage}};

--- a/spi_mem_manager/lib/spi/spi_mem_chip_i.h
+++ b/spi_mem_manager/lib/spi/spi_mem_chip_i.h
@@ -42,7 +42,8 @@ typedef enum {
     SPIMemChipVendorFudan,
     SPIMemChipVendorGenitop,
     SPIMemChipVendorParagon,
-    SPIMemChipVendorXTX
+    SPIMemChipVendorXTX,
+    SPIMemChipVendorXMC
 } SPIMemChipVendor;
 
 typedef enum {


### PR DESCRIPTION
This change adds a definition for two XMC vendor chips to the SPI memory manager app.

# What's new

- Added definition for XMC vendor
- Added definition for XM25QH64C and XM25QH128A memory chips

# Verification 

[Datasheet for XM25QH64C](https://www.xmcwh.com/uploads/207/XM25QH64C.pdf)
[Datasheet for XM25QH128A](https://datasheet.lcsc.com/lcsc/1811080425_XMC-XM25QH128AHIG_C328463.pdf)
Both chips uses in Dell latitude laptop series. Tested on latitude 3410.

Steps to verify:
- Compile the .fap binary using `ufbt`;
- Upload the binary to the **apps** folder on Flipper;
- Connect XM25QH64C or XM25QH128A via SPI;
- Device must discover chip correct and define model and vendor as on picture below; read/write/erase actions with memory should work correct.

![spi_memory](https://github.com/flipperdevices/flipperzero-good-faps/assets/114688577/01d113ce-ae3f-4e89-809d-0cd0c0c2b44e)


# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
