### PR TITLE
Picopass: handle NR-MAC auth for legacy cards

### DIFF
--- a/picopass/.catalog/README.md
+++ b/picopass/.catalog/README.md
@@ -35,6 +35,8 @@ There are some situations when the offline loclass may not find a key, such as:
 
 Due to the nature of how secure picopass works, it is possible to emulate some public fields from a card and capture the reader's response, which can be used to authenticate.  Two of the pieces involved in this are the NR and MAC.
 
+These instructions are intended to be performed all at the same time.  If you use the card with the reader between Card Part 1 and Card Part 2, then Card Part 2 will fail.
+
 ## Card Part 1
 
 1. Place card against Flipper Zero

--- a/picopass/picopass_device.c
+++ b/picopass/picopass_device.c
@@ -167,6 +167,11 @@ static bool picopass_device_save_file(
     FuriString* temp_str;
     temp_str = furi_string_alloc();
 
+    if(dev->format == PicopassDeviceSaveFormatPartial) {
+        // Clear key that may have been set when doing key tests for legacy
+        memset(AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0, PICOPASS_BLOCK_LEN);
+    }
+
     do {
         if(use_load_path && !furi_string_empty(dev->load_path)) {
             // Get directory name
@@ -178,7 +183,8 @@ static bool picopass_device_save_file(
             furi_string_printf(temp_str, "%s/%s%s", folder, dev_name, extension);
         }
 
-        if(dev->format == PicopassDeviceSaveFormatHF) {
+        if(dev->format == PicopassDeviceSaveFormatHF ||
+           dev->format == PicopassDeviceSaveFormatPartial) {
             // Open file
             if(!flipper_format_file_open_always(file, furi_string_get_cstr(temp_str))) break;
 
@@ -229,6 +235,9 @@ bool picopass_device_save(PicopassDevice* dev, const char* dev_name) {
     } else if(dev->format == PicopassDeviceSaveFormatSeader) {
         return picopass_device_save_file(
             dev, dev_name, EXT_PATH("apps_data/seader"), ".credential", true);
+    } else if(dev->format == PicopassDeviceSaveFormatPartial) {
+        return picopass_device_save_file(
+            dev, dev_name, STORAGE_APP_DATA_PATH_PREFIX, PICOPASS_APP_EXTENSION, true);
     }
 
     return false;

--- a/picopass/picopass_device.h
+++ b/picopass/picopass_device.h
@@ -71,6 +71,7 @@ typedef enum {
     PicopassDeviceSaveFormatHF,
     PicopassDeviceSaveFormatLF,
     PicopassDeviceSaveFormatSeader,
+    PicopassDeviceSaveFormatPartial,
 } PicopassDeviceSaveFormat;
 
 typedef enum {

--- a/picopass/scenes/picopass_scene_card_menu.c
+++ b/picopass/scenes/picopass_scene_card_menu.c
@@ -106,7 +106,7 @@ bool picopass_scene_card_menu_on_event(void* context, SceneManagerEvent event) {
             scene_manager_set_scene_state(
                 picopass->scene_manager, PicopassSceneCardMenu, SubmenuIndexSave);
             scene_manager_next_scene(picopass->scene_manager, PicopassSceneSaveName);
-            picopass->dev->format = PicopassDeviceSaveFormatHF;
+            picopass->dev->format = PicopassDeviceSaveFormatPartial;
             consumed = true;
         } else if(event.event == SubmenuIndexSaveAsSeader) {
             scene_manager_set_scene_state(


### PR DESCRIPTION
# What's new

- Fixes to the save partial flow when dealing with a non-SE card (found in discord)

# Verification 

- Remove AA1/standard key from dictonary
- Try to read card and get read failed
- Use "Save Partial"
- Emulate partial dump to reader
- Get "NR-MAC Saved!"

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
