### PR TITLE
nfc_magic: Fix support of 4K fobs

### DIFF
--- a/nfc_magic/.catalog/changelog.md
+++ b/nfc_magic/.catalog/changelog.md
@@ -1,5 +1,9 @@
 ## 1.4 
 
+ - Fix incorrect max sector configuration
+
+## 1.4 
+
  - Auth with password option moved into new submenu "Gen4 actions"
  - New function: Get gen4 card revision
  - New function: Get gen4 card config (shows only when debug ON)

--- a/nfc_magic/application.fam
+++ b/nfc_magic/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Application for writing to NFC tags with modifiable sector 0",
-    fap_version="1.4",
+    fap_version="1.5",
     fap_icon="assets/125_10px.png",
     fap_category="NFC",
     fap_private_libs=[

--- a/nfc_magic/lib/magic/protocols/gen4/gen4_poller.c
+++ b/nfc_magic/lib/magic/protocols/gen4/gen4_poller.c
@@ -274,7 +274,7 @@ static NfcCommand gen4_poller_write_mf_classic(Gen4Poller* instance) {
             instance->config[25] = iso3_data->atqa[1];
             instance->config[26] = iso3_data->sak;
             instance->config[27] = 0x00;
-            instance->config[28] = instance->total_blocks;
+            instance->config[28] = instance->total_blocks - 1;
             instance->config[29] = 0x01;
 
             Gen4PollerError error = gen4_poller_set_config(
@@ -353,7 +353,7 @@ static NfcCommand gen4_poller_write_mf_ultralight(Gen4Poller* instance) {
             instance->config[25] = iso3_data->atqa[1];
             instance->config[26] = iso3_data->sak;
             instance->config[27] = 0x00;
-            instance->config[28] = instance->total_blocks;
+            instance->config[28] = instance->total_blocks - 1;
             instance->config[29] = 0x01;
 
             Gen4PollerError error = gen4_poller_set_config(


### PR DESCRIPTION
# What's new

What's currently being added to the config structure was the total amount of blocks - as per this definition - which is [`256`](https://github.com/flipperdevices/flipperzero-firmware/blob/a7b60bf2a610e1a364d26a925f3713c08d16d49c/lib/nfc/protocols/mf_classic/mf_classic.c#L37).

However, what needs to be sent is the `maximum sector data` ([as per the Proxmark3 Gen4 card notes](https://github.com/RfidResearchGroup/proxmark3/blob/master/doc/magic_cards_notes.md#set-ultralight-and-m1-maximum-readwrite-sectors)). That's because the first block is `0`, not `1`. So if you need `256` blocks, you actually need to be able to write up to the 255th block - i.e. send `255` - well more specifically, `0xFF`.

Effectively, this also "fixes" the fact that for each card being cloned, an extra sector was being provisioned as writable when using a Flipper Zero.

# Why

I was having issues cloning an  S70 fob (7b UID, 4k data), because as soon as it was written by the Flipper, it would be immediately read as a Mifare Mini 0.3k... I bought a Proxmark3, and after reading the backdoor config from the card, I saw that the `6B` setting was set to `0x00`.

That's because the config is a structure storing `uint8_t`, so trying to store the amount of blocks (`256`) instead of the maximum sector data we need (`255`) was causing an integer overflow... Because obviously, storing `256` needs more than 8 bits.

# Verification 

- [x] Build and launch `nfc_magic` with the change.
- [x] Write any 4k tag to a Gen4 card.
- [x] Read the Gen4 card, and see how it is not being recognized as a Gen4 tag.
- [x] (If you have a reader that allows you to check the raw config of a Gen4 tag) Check that the 29th bit of the config is `0xFF` and not `0x00`.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
