### PR TITLE
picopass: Add support for non-secure cards

### DIFF
--- a/picopass/.gitignore
+++ b/picopass/.gitignore
@@ -2,3 +2,5 @@ dist/*
 .vscode
 .clang-format
 .editorconfig
+.env
+.ufbt

--- a/picopass/lib/loclass/optimized_cipher.c
+++ b/picopass/lib/loclass/optimized_cipher.c
@@ -214,7 +214,7 @@ void loclass_opt_doReaderMAC(uint8_t* cc_nr_p, uint8_t* div_key_p, uint8_t mac[4
 
 void loclass_opt_doReaderMAC_2(
     LoclassState_t _init,
-    uint8_t* nr,
+    const uint8_t* nr,
     uint8_t mac[4],
     const uint8_t* div_key_p) {
     loclass_opt_suc(div_key_p, &_init, nr, 4, false);
@@ -268,7 +268,7 @@ LoclassState_t loclass_opt_doTagMAC_1(uint8_t* cc_p, const uint8_t* div_key_p) {
  */
 void loclass_opt_doTagMAC_2(
     LoclassState_t _init,
-    uint8_t* nr,
+    const uint8_t* nr,
     uint8_t mac[4],
     const uint8_t* div_key_p) {
     loclass_opt_suc(div_key_p, &_init, nr, 4, true);
@@ -286,7 +286,7 @@ void loclass_opt_doTagMAC_2(
  */
 void loclass_opt_doBothMAC_2(
     LoclassState_t _init,
-    uint8_t* nr,
+    const uint8_t* nr,
     uint8_t rmac[4],
     uint8_t tmac[4],
     const uint8_t* div_key_p) {

--- a/picopass/lib/loclass/optimized_cipher.h
+++ b/picopass/lib/loclass/optimized_cipher.h
@@ -60,7 +60,7 @@ void loclass_opt_doReaderMAC(uint8_t* cc_nr_p, uint8_t* div_key_p, uint8_t mac[4
 
 void loclass_opt_doReaderMAC_2(
     LoclassState_t _init,
-    uint8_t* nr,
+    const uint8_t* nr,
     uint8_t mac[4],
     const uint8_t* div_key_p);
 
@@ -89,7 +89,7 @@ LoclassState_t loclass_opt_doTagMAC_1(uint8_t* cc_p, const uint8_t* div_key_p);
  */
 void loclass_opt_doTagMAC_2(
     LoclassState_t _init,
-    uint8_t* nr,
+    const uint8_t* nr,
     uint8_t mac[4],
     const uint8_t* div_key_p);
 
@@ -103,7 +103,7 @@ void loclass_opt_doTagMAC_2(
  */
 void loclass_opt_doBothMAC_2(
     LoclassState_t _init,
-    uint8_t* nr,
+    const uint8_t* nr,
     uint8_t rmac[4],
     uint8_t tmac[4],
     const uint8_t* div_key_p);

--- a/picopass/picopass_device.h
+++ b/picopass/picopass_device.h
@@ -40,8 +40,8 @@
 // Crypt1 // 1+1 (crypt1+crypt0) means secured and keys changable
 #define PICOPASS_FUSE_CRYPT1 0x10
 // Crypt0 // 1+0 means secure and keys locked, 0+1 means not secured, 0+0 means disable auth entirely
-#define PICOPASS_FUSE_CRTPT0 0x08
-#define PICOPASS_FUSE_CRYPT10 (PICOPASS_FUSE_CRYPT1 | PICOPASS_FUSE_CRTPT0)
+#define PICOPASS_FUSE_CRYPT0 0x08
+#define PICOPASS_FUSE_CRYPT10 (PICOPASS_FUSE_CRYPT1 | PICOPASS_FUSE_CRYPT0)
 // Read Access, 1 meanns anonymous read enabled, 0 means must auth to read applicaion
 #define PICOPASS_FUSE_RA 0x01
 

--- a/picopass/picopass_i.h
+++ b/picopass/picopass_i.h
@@ -90,6 +90,7 @@ struct Picopass {
     PicopassPoller* poller;
     PicopassListener* listener;
     KeysDict* dict;
+    uint32_t last_error_notify_ticks;
 
     char text_store[PICOPASS_TEXT_STORE_SIZE];
     FuriString* text_box_store;

--- a/picopass/protocol/picopass_poller.h
+++ b/picopass/protocol/picopass_poller.h
@@ -16,6 +16,7 @@ typedef enum {
     PicopassPollerEventTypeRequestWriteKey,
     PicopassPollerEventTypeSuccess,
     PicopassPollerEventTypeFail,
+    PicopassPollerEventTypeAuthFail,
 } PicopassPollerEventType;
 
 typedef enum {

--- a/picopass/protocol/picopass_poller_i.h
+++ b/picopass/protocol/picopass_poller_i.h
@@ -45,6 +45,7 @@ struct PicopassPoller {
     uint8_t div_key[8];
     uint8_t current_block;
     uint8_t app_limit;
+    bool secured;
 
     PicopassDeviceData* data;
 

--- a/picopass/protocol/picopass_poller_i.h
+++ b/picopass/protocol/picopass_poller_i.h
@@ -29,6 +29,7 @@ typedef enum {
     PicopassPollerStateParseWiegand,
     PicopassPollerStateSuccess,
     PicopassPollerStateFail,
+    PicopassPollerStateAuthFail,
 
     PicopassPollerStateNum,
 } PicopassPollerState;

--- a/picopass/scenes/picopass_scene_card_menu.c
+++ b/picopass/scenes/picopass_scene_card_menu.c
@@ -24,8 +24,13 @@ void picopass_scene_card_menu_on_enter(void* context) {
 
     bool sio = 0x30 == AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
     bool no_key = picopass_is_memset(pacs->key, 0x00, PICOPASS_BLOCK_LEN);
+    bool secured = (AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
+                   PICOPASS_FUSE_CRYPT0;
 
-    if(no_key) {
+    if(!secured) {
+        submenu_add_item(
+            submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);
+    } else if(no_key) {
         if(sio) {
             submenu_add_item(
                 submenu,

--- a/picopass/scenes/picopass_scene_elite_dict_attack.c
+++ b/picopass/scenes/picopass_scene_elite_dict_attack.c
@@ -87,12 +87,10 @@ NfcCommand picopass_elite_dict_attack_worker_callback(PicopassPollerEvent event,
                     picopass->view_dispatcher, PicopassCustomEventDictAttackUpdateView);
             }
         }
-    } else if(event.type == PicopassPollerEventTypeSuccess) {
-        const PicopassDeviceData* data = picopass_poller_get_data(picopass->poller);
-        memcpy(&picopass->dev->dev_data, data, sizeof(PicopassDeviceData));
-        view_dispatcher_send_custom_event(
-            picopass->view_dispatcher, PicopassCustomEventPollerSuccess);
-    } else if(event.type == PicopassPollerEventTypeFail) {
+    } else if(
+        event.type == PicopassPollerEventTypeSuccess ||
+        event.type == PicopassPollerEventTypeFail ||
+        event.type == PicopassPollerEventTypeAuthFail) {
         const PicopassDeviceData* data = picopass_poller_get_data(picopass->poller);
         memcpy(&picopass->dev->dev_data, data, sizeof(PicopassDeviceData));
         view_dispatcher_send_custom_event(

--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -45,10 +45,25 @@ void picopass_scene_read_card_success_on_enter(void* context) {
         AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
     bool SE = 0x30 == AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
     bool configCard = (AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[7] >> 2 & 3) == 2;
+    bool secured = (AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
+                   PICOPASS_FUSE_CRYPT0;
+    bool hid_csn = picopass_device_hid_csn(picopass->dev);
 
-    if(no_key) {
+    if(!secured) {
+        furi_string_cat_printf(wiegand_str, "Non-Secured Chip");
+
+        if(!hid_csn) {
+            furi_string_cat_printf(credential_str, "Non-HID CSN");
+        }
+
+        widget_add_button_element(
+            widget,
+            GuiButtonTypeRight,
+            "More",
+            picopass_scene_read_card_success_widget_callback,
+            picopass);
+    } else if(no_key) {
         furi_string_cat_printf(wiegand_str, "Read Failed");
-        bool hid_csn = picopass_device_hid_csn(picopass->dev);
 
         if(pacs->se_enabled) {
             furi_string_cat_printf(credential_str, "SE enabled");

--- a/picopass/scenes/picopass_scene_write_card.c
+++ b/picopass/scenes/picopass_scene_write_card.c
@@ -31,7 +31,9 @@ NfcCommand picopass_scene_write_poller_callback(PicopassPollerEvent event, void*
     } else if(event.type == PicopassPollerEventTypeSuccess) {
         view_dispatcher_send_custom_event(
             picopass->view_dispatcher, PicopassCustomEventPollerSuccess);
-    } else if(event.type == PicopassPollerEventTypeFail) {
+    } else if(
+        event.type == PicopassPollerEventTypeFail ||
+        event.type == PicopassPollerEventTypeAuthFail) {
         view_dispatcher_send_custom_event(
             picopass->view_dispatcher, PicopassCustomEventPollerFail);
     }

--- a/picopass/scenes/picopass_scene_write_key.c
+++ b/picopass/scenes/picopass_scene_write_key.c
@@ -21,7 +21,9 @@ NfcCommand picopass_scene_write_key_poller_callback(PicopassPollerEvent event, v
     } else if(event.type == PicopassPollerEventTypeSuccess) {
         view_dispatcher_send_custom_event(
             picopass->view_dispatcher, PicopassCustomEventPollerSuccess);
-    } else if(event.type == PicopassPollerEventTypeFail) {
+    } else if(
+        event.type == PicopassPollerEventTypeFail ||
+        event.type == PicopassPollerEventTypeAuthFail) {
         view_dispatcher_send_custom_event(
             picopass->view_dispatcher, PicopassCustomEventPollerFail);
     }


### PR DESCRIPTION
# What's new

- Adds support for reading and emulating non-secure picopass cards
- Improves reliability of reads

# Verification 

- Read and emulate a non-secure picopass chip

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
