### PR TITLE
Picopass nr mac improvements

### DIFF
--- a/picopass/scenes/picopass_scene_card_menu.c
+++ b/picopass/scenes/picopass_scene_card_menu.c
@@ -23,35 +23,30 @@ void picopass_scene_card_menu_on_enter(void* context) {
     PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
 
     bool sio = 0x30 == AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
-    bool no_key = picopass_is_memset(pacs->key, 0x00, PICOPASS_BLOCK_LEN);
     bool secured = (AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
                    PICOPASS_FUSE_CRYPT0;
+    bool zero_config = picopass_is_memset(
+        AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
 
     if(!secured) {
         submenu_add_item(
             submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);
-    } else if(no_key) {
-        if(sio) {
-            submenu_add_item(
-                submenu,
-                "Save",
-                SubmenuIndexSave,
-                picopass_scene_card_menu_submenu_callback,
-                picopass);
-            submenu_add_item(
-                submenu,
-                "Save in Seader fmt",
-                SubmenuIndexSaveAsSeader,
-                picopass_scene_card_menu_submenu_callback,
-                picopass);
-        } else {
-            submenu_add_item(
-                submenu,
-                "Save Partial",
-                SubmenuIndexSavePartial,
-                picopass_scene_card_menu_submenu_callback,
-                picopass);
-        }
+    } else if(zero_config) {
+        submenu_add_item(
+            submenu,
+            "Save Partial",
+            SubmenuIndexSavePartial,
+            picopass_scene_card_menu_submenu_callback,
+            picopass);
+    } else if(sio) {
+        submenu_add_item(
+            submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);
+        submenu_add_item(
+            submenu,
+            "Save in Seader fmt",
+            SubmenuIndexSaveAsSeader,
+            picopass_scene_card_menu_submenu_callback,
+            picopass);
     } else {
         submenu_add_item(
             submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);

--- a/picopass/scenes/picopass_scene_card_menu.c
+++ b/picopass/scenes/picopass_scene_card_menu.c
@@ -27,43 +27,41 @@ void picopass_scene_card_menu_on_enter(void* context) {
                    PICOPASS_FUSE_CRYPT0;
     bool zero_config = picopass_is_memset(
         AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
+    bool no_credential = picopass_is_memset(pacs->credential, 0x00, sizeof(pacs->credential));
+    bool no_key =
+        picopass_is_memset(AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
 
-    if(!secured) {
-        submenu_add_item(
-            submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);
-    } else if(zero_config) {
+    if(secured && zero_config) {
         submenu_add_item(
             submenu,
             "Save Partial",
             SubmenuIndexSavePartial,
             picopass_scene_card_menu_submenu_callback,
             picopass);
-    } else if(sio) {
+    } else {
         submenu_add_item(
             submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);
+    }
+
+    if(secured && (sio || pacs->sio)) {
         submenu_add_item(
             submenu,
             "Save in Seader fmt",
             SubmenuIndexSaveAsSeader,
             picopass_scene_card_menu_submenu_callback,
             picopass);
-    } else {
-        submenu_add_item(
-            submenu, "Save", SubmenuIndexSave, picopass_scene_card_menu_submenu_callback, picopass);
+    }
+
+    if(secured && !no_credential) {
         submenu_add_item(
             submenu,
             "Save as LFRFID",
             SubmenuIndexSaveAsLF,
             picopass_scene_card_menu_submenu_callback,
             picopass);
-        if(pacs->sio) { // SR
-            submenu_add_item(
-                submenu,
-                "Save in Seader fmt",
-                SubmenuIndexSaveAsSeader,
-                picopass_scene_card_menu_submenu_callback,
-                picopass);
-        }
+    }
+
+    if(!zero_config && !no_key) {
         submenu_add_item(
             submenu,
             "Write",
@@ -76,12 +74,14 @@ void picopass_scene_card_menu_on_enter(void* context) {
             SubmenuIndexEmulate,
             picopass_scene_card_menu_submenu_callback,
             picopass);
-        submenu_add_item(
-            submenu,
-            "Change Key",
-            SubmenuIndexChangeKey,
-            picopass_scene_card_menu_submenu_callback,
-            picopass);
+        if(secured) {
+            submenu_add_item(
+                submenu,
+                "Change Key",
+                SubmenuIndexChangeKey,
+                picopass_scene_card_menu_submenu_callback,
+                picopass);
+        }
     }
 
     submenu_set_selected_item(

--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -39,7 +39,7 @@ void picopass_scene_read_card_success_on_enter(void* context) {
     }
 
     // We can't test the pacs->key in case it is intentionally all 0's and we can't test the key block since it is populated with the diversified key before each key test, so we approximate with the PACS config block being blank.
-    bool no_key = picopass_is_memset(
+    bool zero_config = picopass_is_memset(
         AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
     bool empty = picopass_is_memset(
         AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
@@ -62,7 +62,7 @@ void picopass_scene_read_card_success_on_enter(void* context) {
             "More",
             picopass_scene_read_card_success_widget_callback,
             picopass);
-    } else if(no_key) {
+    } else if(zero_config) {
         furi_string_cat_printf(wiegand_str, "Read Failed");
 
         if(pacs->se_enabled) {
@@ -133,7 +133,12 @@ void picopass_scene_read_card_success_on_enter(void* context) {
             furi_string_cat_printf(credential_str, " +SIO");
         }
 
-        if(pacs->key) {
+        bool no_key =
+            picopass_is_memset(AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
+
+        if(no_key) {
+            furi_string_cat_printf(key_str, "No Key: used NR-MAC");
+        } else if(pacs->key) {
             furi_string_cat_printf(key_str, "Key: ");
             uint8_t key[PICOPASS_BLOCK_LEN];
             memcpy(key, &pacs->key, PICOPASS_BLOCK_LEN);


### PR DESCRIPTION
# What's new

- Trying to allow saving of non-SE NR-MAC auth'd cards
- Also tries to correct a bad key check (pacs->key === 0 is a bad idea since that could be a valid key)

# Verification 

- use NR-MAC to auth a non-SE card, see a regular "save" option 

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
