### PR TITLE
Picopass read improvements

### DIFF
--- a/picopass/scenes/picopass_scene_start.c
+++ b/picopass/scenes/picopass_scene_start.c
@@ -1,7 +1,6 @@
 #include "../picopass_i.h"
 enum SubmenuIndex {
     SubmenuIndexRead,
-    SubmenuIndexEliteDictAttack,
     SubmenuIndexSaved,
     SubmenuIndexLoclass,
 };
@@ -16,12 +15,6 @@ void picopass_scene_start_on_enter(void* context) {
     Submenu* submenu = picopass->submenu;
     submenu_add_item(
         submenu, "Read Card", SubmenuIndexRead, picopass_scene_start_submenu_callback, picopass);
-    submenu_add_item(
-        submenu,
-        "Elite Dict. Attack",
-        SubmenuIndexEliteDictAttack,
-        picopass_scene_start_submenu_callback,
-        picopass);
     submenu_add_item(
         submenu, "Saved", SubmenuIndexSaved, picopass_scene_start_submenu_callback, picopass);
 
@@ -42,7 +35,7 @@ bool picopass_scene_start_on_event(void* context, SceneManagerEvent event) {
         if(event.event == SubmenuIndexRead) {
             scene_manager_set_scene_state(
                 picopass->scene_manager, PicopassSceneStart, SubmenuIndexRead);
-            scene_manager_next_scene(picopass->scene_manager, PicopassSceneReadCard);
+            scene_manager_next_scene(picopass->scene_manager, PicopassSceneEliteDictAttack);
             consumed = true;
         } else if(event.event == SubmenuIndexSaved) {
             // Explicitly save state so that the correct item is
@@ -50,11 +43,6 @@ bool picopass_scene_start_on_event(void* context, SceneManagerEvent event) {
             scene_manager_set_scene_state(
                 picopass->scene_manager, PicopassSceneStart, SubmenuIndexSaved);
             scene_manager_next_scene(picopass->scene_manager, PicopassSceneFileSelect);
-            consumed = true;
-        } else if(event.event == SubmenuIndexEliteDictAttack) {
-            scene_manager_set_scene_state(
-                picopass->scene_manager, PicopassSceneStart, SubmenuIndexEliteDictAttack);
-            scene_manager_next_scene(picopass->scene_manager, PicopassSceneEliteDictAttack);
             consumed = true;
         } else if(event.event == SubmenuIndexLoclass) {
             scene_manager_set_scene_state(

--- a/picopass/views/dict_attack.c
+++ b/picopass/views/dict_attack.c
@@ -47,7 +47,8 @@ static void dict_attack_draw_callback(Canvas* canvas, void* model) {
                 "Reuse key check for sector: %d",
                 m->key_attack_current_sector);
         } else {
-            snprintf(draw_str, sizeof(draw_str), "Unlocking sector: %d", m->sector_current);
+            snprintf(
+                draw_str, sizeof(draw_str), "Unlocking Application Area %d", m->sector_current + 1);
         }
         canvas_draw_str_aligned(canvas, 0, 10, AlignLeft, AlignTop, draw_str);
         float dict_progress = m->dict_keys_total == 0 ?
@@ -71,7 +72,11 @@ static void dict_attack_draw_callback(Canvas* canvas, void* model) {
         snprintf(draw_str, sizeof(draw_str), "Keys found: %d/%d", m->keys_found, m->keys_total);
         canvas_draw_str_aligned(canvas, 0, 33, AlignLeft, AlignTop, draw_str);
         snprintf(
-            draw_str, sizeof(draw_str), "Sectors Read: %d/%d", m->sectors_read, m->sectors_total);
+            draw_str,
+            sizeof(draw_str),
+            "Application Area Read: %d/%d",
+            m->sectors_read,
+            m->sectors_total);
         canvas_draw_str_aligned(canvas, 0, 43, AlignLeft, AlignTop, draw_str);
     }
     elements_button_center(canvas, "Skip");


### PR DESCRIPTION
# What's new

- Better, more picopass specific, UI during dictionary
- Use elite dictionary attack for default read since our system dictionary has 700 keys and otherwise the lack of screen update is confusing

![Screenshot-20240113-224344](https://github.com/flipperdevices/flipperzero-good-faps/assets/115752/c5956b08-8124-4006-8957-25c1ef4111ef)


# Verification 

- Try reading a card, see progress bar

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
