### PR TITLE
picopass: apply card to back view

### DIFF
--- a/picopass/scenes/picopass_scene_elite_dict_attack.c
+++ b/picopass/scenes/picopass_scene_elite_dict_attack.c
@@ -40,7 +40,6 @@ static bool picopass_elite_dict_attack_change_dict(Picopass* picopass) {
                 PICOPASS_KEY_LEN);
             scene_state = PicopassSceneEliteDictAttackDictElite;
         }
-        picopass->dict_attack_ctx.card_detected = true;
         picopass->dict_attack_ctx.total_keys = keys_dict_get_total_keys(picopass->dict);
         picopass->dict_attack_ctx.current_key = 0;
         picopass->dict_attack_ctx.name = picopass_dict_name[scene_state];
@@ -153,7 +152,7 @@ void picopass_scene_elite_dict_attack_on_enter(void* context) {
             PICOPASS_KEY_LEN);
         state = PicopassSceneEliteDictAttackDictStandard;
     }
-    picopass->dict_attack_ctx.card_detected = true;
+    picopass->dict_attack_ctx.card_detected = false;
     picopass->dict_attack_ctx.total_keys = keys_dict_get_total_keys(picopass->dict);
     picopass->dict_attack_ctx.current_key = 0;
     picopass->dict_attack_ctx.name = picopass_dict_name[state];

--- a/picopass/scenes/picopass_scene_elite_dict_attack.c
+++ b/picopass/scenes/picopass_scene_elite_dict_attack.c
@@ -152,6 +152,7 @@ void picopass_scene_elite_dict_attack_on_enter(void* context) {
             PICOPASS_KEY_LEN);
         state = PicopassSceneEliteDictAttackDictStandard;
     }
+    dict_attack_reset(picopass->dict_attack);
     picopass->dict_attack_ctx.card_detected = false;
     picopass->dict_attack_ctx.total_keys = keys_dict_get_total_keys(picopass->dict);
     picopass->dict_attack_ctx.current_key = 0;

--- a/picopass/views/dict_attack.c
+++ b/picopass/views/dict_attack.c
@@ -84,8 +84,8 @@ static void dict_attack_draw_callback(Canvas* canvas, void* model) {
             m->sectors_read,
             m->sectors_total);
         canvas_draw_str_aligned(canvas, 0, 43, AlignLeft, AlignTop, draw_str);
+        elements_button_center(canvas, "Skip");
     }
-    elements_button_center(canvas, "Skip");
 }
 
 static bool dict_attack_input_callback(InputEvent* event, void* context) {

--- a/picopass/views/dict_attack.c
+++ b/picopass/views/dict_attack.c
@@ -3,6 +3,7 @@
 #include <gui/elements.h>
 
 typedef enum {
+    DictAttackStateStart,
     DictAttackStateRead,
     DictAttackStateCardRemoved,
 } DictAttackState;
@@ -29,7 +30,12 @@ typedef struct {
 
 static void dict_attack_draw_callback(Canvas* canvas, void* model) {
     DictAttackViewModel* m = model;
-    if(m->state == DictAttackStateCardRemoved) {
+    if(m->state == DictAttackStateStart) {
+        canvas_draw_icon(canvas, 0, 8, &I_RFIDDolphinReceive_97x61);
+        canvas_set_font(canvas, FontPrimary);
+        elements_multiline_text_aligned(
+            canvas, 128, 40, AlignRight, AlignCenter, "Apply card to\nthe back");
+    } else if(m->state == DictAttackStateCardRemoved) {
         canvas_set_font(canvas, FontPrimary);
         canvas_draw_str_aligned(canvas, 64, 4, AlignCenter, AlignTop, "Lost the tag!");
         canvas_set_font(canvas, FontSecondary);
@@ -126,7 +132,7 @@ void dict_attack_reset(DictAttack* dict_attack) {
         dict_attack->view,
         DictAttackViewModel * model,
         {
-            model->state = DictAttackStateRead;
+            model->state = DictAttackStateStart;
             model->sectors_total = 1;
             model->sectors_read = 0;
             model->sector_current = 0;
@@ -181,7 +187,12 @@ void dict_attack_set_card_removed(DictAttack* dict_attack) {
     with_view_model(
         dict_attack->view,
         DictAttackViewModel * model,
-        { model->state = DictAttackStateCardRemoved; },
+        {
+            // Only mark card as removed it if had been Read
+            if(model->state == DictAttackStateRead) {
+                model->state = DictAttackStateCardRemoved;
+            }
+        },
         true);
 }
 

--- a/picopass/views/dict_attack.h
+++ b/picopass/views/dict_attack.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <gui/view.h>
 #include <gui/modules/widget.h>
+#include <picopass_icons.h>
 
 typedef struct DictAttack DictAttack;
 


### PR DESCRIPTION
# What's new

- Message if card isn't present

https://github.com/flipperdevices/flipperzero-good-faps/pull/109#issuecomment-1905376781
![Screenshot-20240123-193225](https://github.com/flipperdevices/flipperzero-good-faps/assets/115752/4b2825e3-c587-49cc-a234-c22a02c51b7e)

# Verification 

- Launch picopass->read without a card, see message
- Present card, see dictionary attack

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
