### PR TITLE
Picopass: rename AA1 to card_data

### DIFF
--- a/picopass/picopass_device.h
+++ b/picopass/picopass_device.h
@@ -102,7 +102,7 @@ typedef struct {
 } PicopassBlock;
 
 typedef struct {
-    PicopassBlock AA1[PICOPASS_MAX_APP_LIMIT];
+    PicopassBlock card_data[PICOPASS_MAX_APP_LIMIT];
     PicopassPacs pacs;
 } PicopassDeviceData;
 
@@ -148,6 +148,6 @@ void picopass_device_set_loading_callback(
     PicopassLoadingCallback callback,
     void* context);
 
-void picopass_device_parse_credential(PicopassBlock* AA1, PicopassPacs* pacs);
+void picopass_device_parse_credential(PicopassBlock* card_data, PicopassPacs* pacs);
 void picopass_device_parse_wiegand(uint8_t* credential, PicopassPacs* pacs);
 bool picopass_device_hid_csn(PicopassDevice* dev);

--- a/picopass/protocol/picopass_listener.c
+++ b/picopass/protocol/picopass_listener.c
@@ -43,11 +43,11 @@ static void picopass_listener_loclass_update_csn(PicopassListener* instance) {
     // collect LOCLASS_NUM_PER_CSN nonces in a row for each CSN
     const uint8_t* csn =
         loclass_csns[(instance->key_block_num / LOCLASS_NUM_PER_CSN) % LOCLASS_NUM_CSNS];
-    memcpy(instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data, csn, sizeof(PicopassBlock));
+    memcpy(instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data, csn, sizeof(PicopassBlock));
 
     uint8_t key[PICOPASS_BLOCK_LEN] = {};
     loclass_iclass_calc_div_key(csn, picopass_iclass_key, key, false);
-    memcpy(instance->data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, key, sizeof(PicopassBlock));
+    memcpy(instance->data->card_data[PICOPASS_SECURE_KD_BLOCK_INDEX].data, key, sizeof(PicopassBlock));
 
     picopass_listener_init_cipher_state_key(instance, key);
 }
@@ -118,7 +118,7 @@ PicopassListenerCommand
            (instance->state == PicopassListenerStateIdle)) {
             bit_buffer_copy_bytes(
                 instance->tmp_buffer,
-                instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data,
+                instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data,
                 sizeof(PicopassBlock));
         } else {
             picopass_listener_write_anticoll_csn(instance, instance->tmp_buffer);
@@ -139,7 +139,7 @@ PicopassListenerCommand
         instance->state = PicopassListenerStateSelected;
         bit_buffer_copy_bytes(
             instance->tx_buffer,
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data,
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data,
             sizeof(PicopassBlock));
 
         PicopassError error = picopass_listener_send_frame(instance, instance->tx_buffer);
@@ -162,7 +162,7 @@ PicopassListenerCommand
         uint8_t block_num = bit_buffer_get_byte(buf, 1);
         if(block_num > PICOPASS_MAX_APP_LIMIT) break;
 
-        bool secured = (instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
+        bool secured = (instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
                         PICOPASS_FUSE_CRYPT10) != PICOPASS_FUSE_CRYPT0;
 
         // TODO: Check CRC?
@@ -176,7 +176,7 @@ PicopassListenerCommand
             }
         } else {
             bit_buffer_copy_bytes(
-                instance->tx_buffer, instance->data->AA1[block_num].data, sizeof(PicopassBlock));
+                instance->tx_buffer, instance->data->card_data[block_num].data, sizeof(PicopassBlock));
         }
         PicopassError error = picopass_listener_send_frame(instance, instance->tx_buffer);
         if(error != PicopassErrorNone) {
@@ -211,7 +211,7 @@ static PicopassListenerCommand
 
         // DATA(8)
         bit_buffer_copy_bytes(
-            instance->tx_buffer, instance->data->AA1[block_num].data, sizeof(PicopassBlock));
+            instance->tx_buffer, instance->data->card_data[block_num].data, sizeof(PicopassBlock));
         NfcError error = nfc_listener_tx(instance->nfc, instance->tx_buffer);
         if(error != NfcErrorNone) {
             FURI_LOG_D(TAG, "Failed to tx read check response: %d", error);
@@ -244,7 +244,7 @@ PicopassListenerCommand
 #ifndef PICOPASS_DEBUG_IGNORE_LOCLASS_STD_KEY
         // loclass mode stores the derived standard debit key in Kd to check
 
-        PicopassBlock key = instance->data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX];
+        PicopassBlock key = instance->data->card_data[PICOPASS_SECURE_KD_BLOCK_INDEX];
         uint8_t rmac[4];
         const uint8_t* rx_data = bit_buffer_get_data(buf);
         loclass_opt_doReaderMAC_2(instance->cipher_state, &rx_data[1], rmac, key.data);
@@ -285,8 +285,8 @@ PicopassListenerCommand
                 loclass_writer_write_params(
                     instance->writer,
                     instance->key_block_num + i - LOCLASS_NUM_PER_CSN,
-                    instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data,
-                    instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data,
+                    instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data,
+                    instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data,
                     instance->loclass_mac_buffer + (i * 8),
                     instance->loclass_mac_buffer + (i * 8) + 4);
             }
@@ -314,8 +314,8 @@ PicopassListenerCommand
 
     PicopassDevice* dev = picopass->dev;
 
-    const uint8_t* csn = instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data;
-    const uint8_t* epurse = instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data;
+    const uint8_t* csn = instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data;
+    const uint8_t* epurse = instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data;
 
     FuriString* temp_str = furi_string_alloc();
     FuriString* filename = furi_string_alloc();
@@ -368,13 +368,13 @@ PicopassListenerCommand
     PicopassListenerCommand command = PicopassListenerCommandSilent;
 
     do {
-        bool secured = (instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
+        bool secured = (instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
                         PICOPASS_FUSE_CRYPT10) != PICOPASS_FUSE_CRYPT0;
         if(!secured) break;
 
         uint8_t rmac[4] = {};
         uint8_t tmac[4] = {};
-        const uint8_t* key = instance->data->AA1[instance->key_block_num].data;
+        const uint8_t* key = instance->data->card_data[instance->key_block_num].data;
         bool no_key = picopass_is_memset(key, 0x00, PICOPASS_BLOCK_LEN);
         const uint8_t* rx_data = bit_buffer_get_data(buf);
 
@@ -432,9 +432,9 @@ PicopassListenerCommand
         if(instance->mode == PicopassListenerModeLoclass) break;
         if(instance->state != PicopassListenerStateSelected) break;
 
-        PicopassBlock config_block = instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX];
+        PicopassBlock config_block = instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX];
         bool pers_mode = PICOPASS_LISTENER_HAS_MASK(config_block.data[7], PICOPASS_FUSE_PERS);
-        bool secured = (instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
+        bool secured = (instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
                         PICOPASS_FUSE_CRYPT10) != PICOPASS_FUSE_CRYPT0;
 
         const uint8_t* rx_data = bit_buffer_get_data(buf);
@@ -502,7 +502,7 @@ PicopassListenerCommand
             // fallthrough
         case PICOPASS_SECURE_KC_BLOCK_INDEX:
             if(!pers_mode && secured) {
-                new_block = instance->data->AA1[block_num];
+                new_block = instance->data->card_data[block_num];
                 for(size_t i = 0; i < sizeof(PicopassBlock); i++) {
                     new_block.data[i] ^= rx_data[i + 2];
                 }
@@ -515,7 +515,7 @@ PicopassListenerCommand
             break;
         }
 
-        instance->data->AA1[block_num] = new_block;
+        instance->data->card_data[block_num] = new_block;
         if(secured && ((block_num == instance->key_block_num) ||
                        (block_num == PICOPASS_SECURE_EPURSE_BLOCK_INDEX))) {
             picopass_listener_init_cipher_state(instance);
@@ -530,7 +530,7 @@ PicopassListenerCommand
             }
         } else {
             bit_buffer_copy_bytes(
-                instance->tx_buffer, instance->data->AA1[block_num].data, sizeof(PicopassBlock));
+                instance->tx_buffer, instance->data->card_data[block_num].data, sizeof(PicopassBlock));
         }
 
         PicopassError error = picopass_listener_send_frame(instance, instance->tx_buffer);
@@ -555,7 +555,7 @@ PicopassListenerCommand
         uint8_t block_start = bit_buffer_get_byte(buf, 1);
         if(block_start + 4 >= PICOPASS_MAX_APP_LIMIT) break;
 
-        bool secured = (instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
+        bool secured = (instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] &
                         PICOPASS_FUSE_CRYPT10) != PICOPASS_FUSE_CRYPT0;
 
         // TODO: Check CRC?
@@ -570,7 +570,7 @@ PicopassListenerCommand
                 }
             } else {
                 bit_buffer_append_bytes(
-                    instance->tx_buffer, instance->data->AA1[i].data, sizeof(PicopassBlock));
+                    instance->tx_buffer, instance->data->card_data[i].data, sizeof(PicopassBlock));
             }
         }
 

--- a/picopass/protocol/picopass_listener_i.c
+++ b/picopass/protocol/picopass_listener_i.c
@@ -21,14 +21,14 @@ static PicopassError picopass_listener_process_error(NfcError error) {
 void picopass_listener_init_cipher_state_key(PicopassListener* instance, const uint8_t* key) {
     uint8_t cc[PICOPASS_BLOCK_LEN] = {};
     memcpy(
-        cc, instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data, sizeof(PicopassBlock));
+        cc, instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data, sizeof(PicopassBlock));
 
     instance->cipher_state = loclass_opt_doTagMAC_1(cc, key);
 }
 
 void picopass_listener_init_cipher_state(PicopassListener* instance) {
     uint8_t key[PICOPASS_BLOCK_LEN] = {};
-    memcpy(key, instance->data->AA1[instance->key_block_num].data, sizeof(PicopassBlock));
+    memcpy(key, instance->data->card_data[instance->key_block_num].data, sizeof(PicopassBlock));
 
     picopass_listener_init_cipher_state_key(instance, key);
 }
@@ -42,7 +42,7 @@ PicopassError picopass_listener_send_frame(PicopassListener* instance, BitBuffer
 
 // from proxmark3 armsrc/iclass.c rotateCSN
 PicopassError picopass_listener_write_anticoll_csn(PicopassListener* instance, BitBuffer* buffer) {
-    const uint8_t* uid = instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data;
+    const uint8_t* uid = instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data;
     bit_buffer_reset(buffer);
     for(size_t i = 0; i < PICOPASS_BLOCK_LEN; i++) {
         bit_buffer_append_byte(buffer, (uid[i] >> 3) | (uid[(i + 1) % 8] << 5));

--- a/picopass/protocol/picopass_poller.c
+++ b/picopass/protocol/picopass_poller.c
@@ -14,9 +14,9 @@ static void picopass_poller_reset(PicopassPoller* instance) {
 }
 
 static void picopass_poller_prepare_read(PicopassPoller* instance) {
-    instance->app_limit = instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[0] <
+    instance->app_limit = instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[0] <
                                   PICOPASS_MAX_APP_LIMIT ?
-                              instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[0] :
+                              instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[0] :
                               PICOPASS_MAX_APP_LIMIT;
     instance->current_block = 2;
 }
@@ -76,20 +76,20 @@ NfcCommand picopass_poller_pre_auth_handler(PicopassPoller* instance) {
 
     do {
         memcpy(
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data,
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data,
             instance->serial_num.data,
             sizeof(PicopassSerialNum));
         FURI_LOG_D(
             TAG,
             "csn %02x%02x%02x%02x%02x%02x%02x%02x",
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[0],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[1],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[2],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[3],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[4],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[5],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[6],
-            instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data[7]);
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[0],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[1],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[2],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[3],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[4],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[5],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[6],
+            instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data[7]);
 
         PicopassBlock block = {};
         error = picopass_poller_read_block(instance, PICOPASS_CONFIG_BLOCK_INDEX, &block);
@@ -98,20 +98,20 @@ NfcCommand picopass_poller_pre_auth_handler(PicopassPoller* instance) {
             break;
         }
         memcpy(
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data,
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data,
             block.data,
             sizeof(PicopassBlock));
         FURI_LOG_D(
             TAG,
             "config %02x%02x%02x%02x%02x%02x%02x%02x",
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[0],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[1],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[2],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[3],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[4],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[5],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[6],
-            instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7]);
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[0],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[1],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[2],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[3],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[4],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[5],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[6],
+            instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7]);
 
         error = picopass_poller_read_block(instance, PICOPASS_SECURE_EPURSE_BLOCK_INDEX, &block);
         if(error != PicopassErrorNone) {
@@ -119,20 +119,20 @@ NfcCommand picopass_poller_pre_auth_handler(PicopassPoller* instance) {
             break;
         }
         memcpy(
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data,
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data,
             block.data,
             sizeof(PicopassBlock));
         FURI_LOG_D(
             TAG,
             "epurse %02x%02x%02x%02x%02x%02x%02x%02x",
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[0],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[1],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[2],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[3],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[4],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[5],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[6],
-            instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[7]);
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[0],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[1],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[2],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[3],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[4],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[5],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[6],
+            instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data[7]);
 
         error = picopass_poller_read_block(instance, PICOPASS_SECURE_AIA_BLOCK_INDEX, &block);
         if(error != PicopassErrorNone) {
@@ -140,20 +140,20 @@ NfcCommand picopass_poller_pre_auth_handler(PicopassPoller* instance) {
             break;
         }
         memcpy(
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data,
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data,
             block.data,
             sizeof(PicopassBlock));
         FURI_LOG_D(
             TAG,
             "aia %02x%02x%02x%02x%02x%02x%02x%02x",
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[0],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[1],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[2],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[3],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[4],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[5],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[6],
-            instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[7]);
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[0],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[1],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[2],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[3],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[4],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[5],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[6],
+            instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data[7]);
 
         instance->state = PicopassPollerStateCheckSecurity;
     } while(false);
@@ -167,7 +167,7 @@ NfcCommand picopass_poller_check_security(PicopassPoller* instance) {
     instance->secured = true;
 
     uint8_t crypt =
-        (instance->data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10);
+        (instance->data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10);
     switch(crypt) {
     case 0:
         FURI_LOG_D(TAG, "Secured page - Authentication disabled");
@@ -191,7 +191,7 @@ NfcCommand picopass_poller_check_security(PicopassPoller* instance) {
     memset(temp_block.data, 0xff, sizeof(PicopassBlock));
     instance->data->pacs.legacy =
         (memcmp(
-             instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data,
+             instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data,
              temp_block.data,
              sizeof(PicopassBlock)) == 0);
 
@@ -199,7 +199,7 @@ NfcCommand picopass_poller_check_security(PicopassPoller* instance) {
     temp_block.data[4] = 0x06;
     instance->data->pacs.se_enabled =
         (memcmp(
-             instance->data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data,
+             instance->data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data,
              temp_block.data,
              sizeof(PicopassBlock)) == 0);
 
@@ -222,8 +222,8 @@ NfcCommand picopass_poller_nr_mac_auth(PicopassPoller* instance) {
     Picopass* picopass = instance->context;
     PicopassDevice* dev = picopass->dev;
 
-    uint8_t* csn = instance->data->AA1[PICOPASS_CSN_BLOCK_INDEX].data;
-    uint8_t* epurse = instance->data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data;
+    uint8_t* csn = instance->data->card_data[PICOPASS_CSN_BLOCK_INDEX].data;
+    uint8_t* epurse = instance->data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data;
 
     FuriString* temp_str = furi_string_alloc();
     FuriString* filename = furi_string_alloc();
@@ -315,11 +315,11 @@ NfcCommand picopass_poller_nr_mac_auth(PicopassPoller* instance) {
                 instance->state = PicopassPollerStateReadBlock;
                 // Set to non-zero keys to allow emulation
                 memset(
-                    instance->data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data,
+                    instance->data->card_data[PICOPASS_SECURE_KD_BLOCK_INDEX].data,
                     0xff,
                     PICOPASS_BLOCK_LEN);
                 memset(
-                    instance->data->AA1[PICOPASS_SECURE_KC_BLOCK_INDEX].data,
+                    instance->data->card_data[PICOPASS_SECURE_KC_BLOCK_INDEX].data,
                     0xff,
                     PICOPASS_BLOCK_LEN);
             }
@@ -366,7 +366,7 @@ NfcCommand picopass_poller_auth_handler(PicopassPoller* instance) {
         uint8_t* div_key = NULL;
 
         if(instance->mode == PicopassPollerModeRead) {
-            div_key = instance->data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data;
+            div_key = instance->data->card_data[PICOPASS_SECURE_KD_BLOCK_INDEX].data;
         } else {
             div_key = instance->div_key;
         }
@@ -455,7 +455,7 @@ NfcCommand picopass_poller_read_block_handler(PicopassPoller* instance) {
             block.data[6],
             block.data[7]);
         memcpy(
-            instance->data->AA1[instance->current_block].data, block.data, sizeof(PicopassBlock));
+            instance->data->card_data[instance->current_block].data, block.data, sizeof(PicopassBlock));
         instance->current_block++;
     } while(false);
 
@@ -465,7 +465,7 @@ NfcCommand picopass_poller_read_block_handler(PicopassPoller* instance) {
 NfcCommand picopass_poller_parse_credential_handler(PicopassPoller* instance) {
     NfcCommand command = NfcCommandContinue;
 
-    picopass_device_parse_credential(instance->data->AA1, &instance->data->pacs);
+    picopass_device_parse_credential(instance->data->card_data, &instance->data->pacs);
     instance->state = PicopassPollerStateParseWiegand;
     return command;
 }
@@ -540,10 +540,10 @@ NfcCommand picopass_poller_write_key_handler(PicopassPoller* instance) {
         const uint8_t* new_key = instance->event_data.req_write_key.key;
         bool is_elite_key = instance->event_data.req_write_key.is_elite_key;
 
-        const uint8_t* csn = picopass_data->AA1[PICOPASS_CSN_BLOCK_INDEX].data;
-        const uint8_t* config_block = picopass_data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data;
+        const uint8_t* csn = picopass_data->card_data[PICOPASS_CSN_BLOCK_INDEX].data;
+        const uint8_t* config_block = picopass_data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data;
         uint8_t fuses = config_block[7];
-        const uint8_t* old_key = picopass_data->AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data;
+        const uint8_t* old_key = picopass_data->card_data[PICOPASS_SECURE_KD_BLOCK_INDEX].data;
 
         PicopassBlock new_block = {};
         loclass_iclass_calc_div_key(csn, new_key, new_block.data, is_elite_key);

--- a/picopass/scenes/picopass_scene_card_menu.c
+++ b/picopass/scenes/picopass_scene_card_menu.c
@@ -20,16 +20,16 @@ void picopass_scene_card_menu_on_enter(void* context) {
     Picopass* picopass = context;
     Submenu* submenu = picopass->submenu;
     PicopassPacs* pacs = &picopass->dev->dev_data.pacs;
-    PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
+    PicopassBlock* card_data = picopass->dev->dev_data.card_data;
 
-    bool sio = 0x30 == AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
-    bool secured = (AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
+    bool sio = 0x30 == card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
+    bool secured = (card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
                    PICOPASS_FUSE_CRYPT0;
     bool zero_config = picopass_is_memset(
-        AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
+        card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
     bool no_credential = picopass_is_memset(pacs->credential, 0x00, sizeof(pacs->credential));
     bool no_key =
-        picopass_is_memset(AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
+        picopass_is_memset(card_data[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
 
     if(secured && zero_config) {
         submenu_add_item(

--- a/picopass/scenes/picopass_scene_device_info.c
+++ b/picopass/scenes/picopass_scene_device_info.c
@@ -21,16 +21,16 @@ void picopass_scene_device_info_on_enter(void* context) {
     dolphin_deed(DolphinDeedNfcReadSuccess);
 
     // Setup view
-    PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
+    PicopassBlock* card_data = picopass->dev->dev_data.card_data;
     PicopassPacs* pacs = &picopass->dev->dev_data.pacs;
     Widget* widget = picopass->widget;
 
     uint8_t csn[PICOPASS_BLOCK_LEN] = {0};
-    memcpy(csn, AA1[PICOPASS_CSN_BLOCK_INDEX].data, PICOPASS_BLOCK_LEN);
+    memcpy(csn, card_data[PICOPASS_CSN_BLOCK_INDEX].data, PICOPASS_BLOCK_LEN);
     for(uint8_t i = 0; i < PICOPASS_BLOCK_LEN; i++) {
         furi_string_cat_printf(csn_str, "%02X ", csn[i]);
     }
-    bool sio = 0x30 == AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
+    bool sio = 0x30 == card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
 
     if(sio) {
         furi_string_cat_printf(wiegand_str, "SIO");

--- a/picopass/scenes/picopass_scene_loclass.c
+++ b/picopass/scenes/picopass_scene_loclass.c
@@ -43,13 +43,13 @@ void picopass_scene_loclass_on_enter(void* context) {
     PicopassDeviceData* data = malloc(sizeof(PicopassDeviceData));
     const uint8_t config_block[PICOPASS_BLOCK_LEN] = {
         0x12, 0xFF, 0xFF, 0xFF, 0x7F, 0x1F, 0xFF, 0x3C};
-    memcpy(data->AA1[PICOPASS_CONFIG_BLOCK_INDEX].data, config_block, sizeof(config_block));
+    memcpy(data->card_data[PICOPASS_CONFIG_BLOCK_INDEX].data, config_block, sizeof(config_block));
 
     const uint8_t epurse[PICOPASS_BLOCK_LEN] = {0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    memcpy(data->AA1[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data, epurse, sizeof(epurse));
+    memcpy(data->card_data[PICOPASS_SECURE_EPURSE_BLOCK_INDEX].data, epurse, sizeof(epurse));
 
     const uint8_t aia[PICOPASS_BLOCK_LEN] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
-    memcpy(data->AA1[PICOPASS_SECURE_AIA_BLOCK_INDEX].data, aia, sizeof(aia));
+    memcpy(data->card_data[PICOPASS_SECURE_AIA_BLOCK_INDEX].data, aia, sizeof(aia));
 
     picopass->listener = picopass_listener_alloc(picopass->nfc, data);
     free(data);

--- a/picopass/scenes/picopass_scene_more_info.c
+++ b/picopass/scenes/picopass_scene_more_info.c
@@ -10,16 +10,16 @@ void picopass_scene_more_info_widget_callback(GuiButtonType result, InputType ty
 
 void picopass_scene_more_info_on_enter(void* context) {
     Picopass* picopass = context;
-    PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
+    PicopassBlock* card_data = picopass->dev->dev_data.card_data;
 
     furi_string_reset(picopass->text_box_store);
 
-    size_t app_limit = MIN(AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[0], PICOPASS_MAX_APP_LIMIT);
+    size_t app_limit = MIN(card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[0], PICOPASS_MAX_APP_LIMIT);
     FuriString* str = picopass->text_box_store;
 
     for(size_t i = 0; i < app_limit; i++) {
         for(size_t j = 0; j < PICOPASS_BLOCK_LEN; j += 2) {
-            furi_string_cat_printf(str, "%02X%02X ", AA1[i].data[j], AA1[i].data[j + 1]);
+            furi_string_cat_printf(str, "%02X%02X ", card_data[i].data[j], card_data[i].data[j + 1]);
         }
     }
 

--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -28,24 +28,24 @@ void picopass_scene_read_card_success_on_enter(void* context) {
     notification_message(picopass->notifications, &sequence_success);
 
     // Setup view
-    PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
+    PicopassBlock* card_data = picopass->dev->dev_data.card_data;
     PicopassPacs* pacs = &picopass->dev->dev_data.pacs;
     Widget* widget = picopass->widget;
 
     uint8_t csn[PICOPASS_BLOCK_LEN] = {0};
-    memcpy(csn, AA1[PICOPASS_CSN_BLOCK_INDEX].data, PICOPASS_BLOCK_LEN);
+    memcpy(csn, card_data[PICOPASS_CSN_BLOCK_INDEX].data, PICOPASS_BLOCK_LEN);
     for(uint8_t i = 0; i < PICOPASS_BLOCK_LEN; i++) {
         furi_string_cat_printf(csn_str, "%02X", csn[i]);
     }
 
     // We can't test the pacs->key in case it is intentionally all 0's and we can't test the key block since it is populated with the diversified key before each key test, so we approximate with the PACS config block being blank.
     bool zero_config = picopass_is_memset(
-        AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
+        card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0x00, PICOPASS_BLOCK_LEN);
     bool empty = picopass_is_memset(
-        AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
-    bool SE = 0x30 == AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
-    bool configCard = (AA1[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[7] >> 2 & 3) == 2;
-    bool secured = (AA1[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
+        card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
+    bool SE = 0x30 == card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[0];
+    bool configCard = (card_data[PICOPASS_ICLASS_PACS_CFG_BLOCK_INDEX].data[7] >> 2 & 3) == 2;
+    bool secured = (card_data[PICOPASS_CONFIG_BLOCK_INDEX].data[7] & PICOPASS_FUSE_CRYPT10) !=
                    PICOPASS_FUSE_CRYPT0;
     bool hid_csn = picopass_device_hid_csn(picopass->dev);
 
@@ -134,7 +134,7 @@ void picopass_scene_read_card_success_on_enter(void* context) {
         }
 
         bool no_key =
-            picopass_is_memset(AA1[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
+            picopass_is_memset(card_data[PICOPASS_SECURE_KD_BLOCK_INDEX].data, 0xFF, PICOPASS_BLOCK_LEN);
 
         if(no_key) {
             furi_string_cat_printf(key_str, "No Key: used NR-MAC");

--- a/picopass/scenes/picopass_scene_read_factory_success.c
+++ b/picopass/scenes/picopass_scene_read_factory_success.c
@@ -27,9 +27,9 @@ void picopass_scene_read_factory_success_on_enter(void* context) {
     // Setup view
     Widget* widget = picopass->widget;
     //PicopassPacs* pacs = &picopass->dev->dev_data.pacs;
-    PicopassBlock* AA1 = picopass->dev->dev_data.AA1;
+    PicopassBlock* card_data = picopass->dev->dev_data.card_data;
 
-    uint8_t* configBlock = AA1[PICOPASS_CONFIG_BLOCK_INDEX].data;
+    uint8_t* configBlock = card_data[PICOPASS_CONFIG_BLOCK_INDEX].data;
     uint8_t fuses = configBlock[7];
 
     if((fuses & 0x80) == 0x80) {

--- a/picopass/scenes/picopass_scene_write_card.c
+++ b/picopass/scenes/picopass_scene_write_card.c
@@ -22,7 +22,7 @@ NfcCommand picopass_scene_write_poller_callback(PicopassPollerEvent event, void*
             event.data->req_write.perform_write = false;
         } else {
             event.data->req_write.block_num = block_num;
-            event.data->req_write.block = &picopass->dev->dev_data.AA1[block_num];
+            event.data->req_write.block = &picopass->dev->dev_data.card_data[block_num];
             event.data->req_write.perform_write = true;
             block_num++;
             scene_manager_set_scene_state(


### PR DESCRIPTION
# What's new

- Rename variable for better accuracy and future true AA1/AA2 support

# Verification 

- Picopass still compiles and runs

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
