### PR TITLE
Rename standart to standard when using UMCs 

### DIFF
--- a/nfc_magic/scenes/nfc_magic_scene_gen4_actions_menu.c
+++ b/nfc_magic/scenes/nfc_magic_scene_gen4_actions_menu.c
@@ -3,7 +3,7 @@
 
 enum SubmenuIndex {
     SubmenuIndexAuthenticate,
-    SubmenuIndexSetStandartConfig,
+    SubmenuIndexSetStandardConfig,
     SubmenuIndexGetConfig,
     SubmenuIndexGetRevision
 };
@@ -32,8 +32,8 @@ void nfc_magic_scene_gen4_actions_menu_on_enter(void* context) {
         instance);
     submenu_add_item(
         submenu,
-        "Set Standart Config",
-        SubmenuIndexSetStandartConfig,
+        "Set Standard Config",
+        SubmenuIndexSetStandardConfig,
         nfc_magic_scene_gen4_actions_menu_submenu_callback,
         instance);
     if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug)) {
@@ -59,7 +59,7 @@ bool nfc_magic_scene_gen4_actions_menu_on_event(void* context, SceneManagerEvent
         if(event.event == SubmenuIndexAuthenticate) {
             scene_manager_next_scene(instance->scene_manager, NfcMagicSceneKeyInput);
             consumed = true;
-        } else if(event.event == SubmenuIndexSetStandartConfig) {
+        } else if(event.event == SubmenuIndexSetStandardConfig) {
             scene_manager_next_scene(instance->scene_manager, NfcMagicSceneGen4SetCFG);
             consumed = true;
         } else if(event.event == SubmenuIndexGetConfig) {


### PR DESCRIPTION
# What's new

- Fix spelling

# Verification 

- Read a UMC and go to gen4 actions menu 
- Set standard config should be spelled correctly in the options 
- Write the standard config to a UMC

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
