### PR TITLE
Picopass: enum to track auth method

### DIFF
--- a/picopass/picopass_device.c
+++ b/picopass/picopass_device.c
@@ -20,10 +20,17 @@ const char unknown_block[] = "?? ?? ?? ?? ?? ?? ?? ??";
 
 PicopassDevice* picopass_device_alloc() {
     PicopassDevice* picopass_dev = malloc(sizeof(PicopassDevice));
+    picopass_dev->dev_data.auth = PicopassDeviceAuthMethodUnset;
     picopass_dev->dev_data.pacs.legacy = false;
     picopass_dev->dev_data.pacs.se_enabled = false;
+    picopass_dev->dev_data.pacs.sio = false;
+    picopass_dev->dev_data.pacs.biometrics = false;
+    memset(picopass_dev->dev_data.pacs.key, 0, sizeof(picopass_dev->dev_data.pacs.key));
     picopass_dev->dev_data.pacs.elite_kdf = false;
     picopass_dev->dev_data.pacs.pin_length = 0;
+    picopass_dev->dev_data.pacs.bitLength = 0;
+    memset(
+        picopass_dev->dev_data.pacs.credential, 0, sizeof(picopass_dev->dev_data.pacs.credential));
     picopass_dev->storage = furi_record_open(RECORD_STORAGE);
     picopass_dev->dialogs = furi_record_open(RECORD_DIALOGS);
     picopass_dev->load_path = furi_string_alloc();
@@ -421,8 +428,8 @@ void picopass_device_data_clear(PicopassDeviceData* dev_data) {
         memset(dev_data->card_data[i].data, 0, sizeof(dev_data->card_data[i].data));
         dev_data->card_data[i].valid = false;
     }
-
     memset(dev_data->pacs.credential, 0, sizeof(dev_data->pacs.credential));
+    dev_data->auth = PicopassDeviceAuthMethodUnset;
     dev_data->pacs.legacy = false;
     dev_data->pacs.se_enabled = false;
     dev_data->pacs.elite_kdf = false;

--- a/picopass/picopass_device.h
+++ b/picopass/picopass_device.h
@@ -75,6 +75,14 @@ typedef enum {
 } PicopassDeviceSaveFormat;
 
 typedef enum {
+    PicopassDeviceAuthMethodUnset,
+    PicopassDeviceAuthMethodNone, // unsecured picopass
+    PicopassDeviceAuthMethodKey,
+    PicopassDeviceAuthMethodNrMac,
+    PicopassDeviceAuthMethodFailed,
+} PicopassDeviceAuthMethod;
+
+typedef enum {
     PicopassEmulatorStateHalt,
     PicopassEmulatorStateIdle,
     PicopassEmulatorStateActive,
@@ -105,6 +113,7 @@ typedef struct {
 typedef struct {
     PicopassBlock card_data[PICOPASS_MAX_APP_LIMIT];
     PicopassPacs pacs;
+    PicopassDeviceAuthMethod auth;
 } PicopassDeviceData;
 
 typedef struct {

--- a/picopass/protocol/picopass_poller.c
+++ b/picopass/protocol/picopass_poller.c
@@ -162,6 +162,7 @@ NfcCommand picopass_poller_check_security(PicopassPoller* instance) {
     case PICOPASS_FUSE_CRYPT0:
         FURI_LOG_D(TAG, "Non-secured page, skipping auth");
         instance->secured = false;
+        instance->data->auth = PicopassDeviceAuthMethodNone;
         picopass_poller_prepare_read(instance);
         instance->state = PicopassPollerStateReadBlock;
         return command;
@@ -193,6 +194,8 @@ NfcCommand picopass_poller_check_security(PicopassPoller* instance) {
         FURI_LOG_D(TAG, "SE enabled");
     }
 
+    // Assume failure since we must auth, correct value will be set on success
+    instance->data->auth = PicopassDeviceAuthMethodFailed;
     if(instance->mode == PicopassPollerModeRead) {
         // Always try the NR-MAC auth in case we have the file.
         instance->state = PicopassPollerStateNrMacAuth;
@@ -295,6 +298,7 @@ NfcCommand picopass_poller_nr_mac_auth(PicopassPoller* instance) {
         PicopassCheckResp check_resp = {};
         error = picopass_poller_check(instance, nr_mac, &mac, &check_resp);
         if(error == PicopassErrorNone) {
+            instance->data->auth = PicopassDeviceAuthMethodNrMac;
             memcpy(instance->mac.data, mac.data, sizeof(PicopassMac));
             if(instance->mode == PicopassPollerModeRead) {
                 picopass_poller_prepare_read(instance);
@@ -383,6 +387,7 @@ NfcCommand picopass_poller_auth_handler(PicopassPoller* instance) {
         error = picopass_poller_check(instance, NULL, &mac, &check_resp);
         if(error == PicopassErrorNone) {
             FURI_LOG_I(TAG, "Found key");
+            instance->data->auth = PicopassDeviceAuthMethodKey;
             memcpy(instance->mac.data, mac.data, sizeof(PicopassMac));
             if(instance->mode == PicopassPollerModeRead) {
                 memcpy(

--- a/picopass/scenes/picopass_scene_read_card_success.c
+++ b/picopass/scenes/picopass_scene_read_card_success.c
@@ -2,6 +2,8 @@
 #include <dolphin/dolphin.h>
 #include <picopass_keys.h>
 
+#define TAG "PicopassSceneReadCardSuccess"
+
 void picopass_scene_read_card_success_widget_callback(
     GuiButtonType result,
     InputType type,
@@ -26,6 +28,28 @@ void picopass_scene_read_card_success_on_enter(void* context) {
 
     // Send notification
     notification_message(picopass->notifications, &sequence_success);
+
+    // For initial testing, print auth method
+    switch(picopass->dev->dev_data.auth) {
+    case PicopassDeviceAuthMethodUnset:
+        FURI_LOG_D(TAG, "Auth: Unset");
+        break;
+    case PicopassDeviceAuthMethodNone:
+        FURI_LOG_D(TAG, "Auth: None");
+        break;
+    case PicopassDeviceAuthMethodKey:
+        FURI_LOG_D(TAG, "Auth: Key");
+        break;
+    case PicopassDeviceAuthMethodNrMac:
+        FURI_LOG_D(TAG, "Auth: NR-MAC");
+        break;
+    case PicopassDeviceAuthMethodFailed:
+        FURI_LOG_D(TAG, "Auth: Failed");
+        break;
+    default:
+        FURI_LOG_D(TAG, "Auth: Unknown");
+        break;
+    };
 
     // Setup view
     PicopassBlock* card_data = picopass->dev->dev_data.card_data;


### PR DESCRIPTION
# What's new

- Tracking auth method so we can display data better

# Verification 

- Turn on debug logging
- Read card
- see `[D][PicopassSceneReadCardSuccess] Auth: Key` in logs

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
