### PR TITLE
[NFC Magic] Fix the user dict attack results being discarded

### DIFF
--- a/nfc_magic/.catalog/README.md
+++ b/nfc_magic/.catalog/README.md
@@ -11,13 +11,13 @@ A Magic card is a card that allows you to change its UID. Generally, NFC cards h
 Currently, not all Magic cards are supported. The following cards are supported:
 
 * Mifare Classic 1K/4K Gen1A/Gen1B (including OTP versions)
+* Mifare Classic 1K/4K Gen2 (DirectWrite/CUID/FUID/UFUID)
 * Ultimate Magic Card (Gen4 GTU)
 
 For the Gen4 cards, both the Ultralight and the Classic modes are supported, with the ability to select a custom password.
 
 The following cards are currently not supported:
 
-* Mifare Classic 1K/4K Gen2 (DirectWrite/CUID/FUID/UFUID)
 * Mifare Classic 1K/4K Gen3 (APDU)
 * Mifare Classic Magic Gen4 (GDM)
 * Supercard (Gen1 and Gen2)

--- a/nfc_magic/.catalog/changelog.md
+++ b/nfc_magic/.catalog/changelog.md
@@ -1,3 +1,6 @@
+## 1.10
+ - Fixed the user dictionary dictionary attack results being discarded
+
 ## 1.9
  - Get revision, get config moved into main Gen4 menu
  - New function: Set Gen4 card shadow mode

--- a/nfc_magic/application.fam
+++ b/nfc_magic/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Application for writing to NFC tags with modifiable sector 0",
-    fap_version="1.9",
+    fap_version="1.10",
     fap_icon="assets/125_10px.png",
     fap_category="NFC",
     fap_icon_assets="assets",

--- a/nfc_magic/scenes/nfc_magic_scene_mf_classic_dict_attack.c
+++ b/nfc_magic/scenes/nfc_magic_scene_mf_classic_dict_attack.c
@@ -32,7 +32,15 @@ NfcCommand nfc_dict_attack_worker_callback(NfcGenericEvent event, void* context)
             instance->view_dispatcher, NfcMagicAppCustomEventCardLost);
     } else if(mfc_event->type == MfClassicPollerEventTypeRequestMode) {
         const MfClassicData* mfc_data = nfc_poller_get_data(instance->poller);
-        nfc_device_set_data(instance->target_dev, NfcProtocolMfClassic, mfc_data);
+
+        if(nfc_device_get_protocol(instance->target_dev) == NfcProtocolInvalid) {
+            FURI_LOG_D(TAG, "Setting MFC data to target device");
+            nfc_device_set_data(instance->target_dev, NfcProtocolMfClassic, mfc_data);
+        } else {
+            FURI_LOG_D(TAG, "MFC data already set to target device");
+            mfc_data = nfc_device_get_data(instance->target_dev, NfcProtocolMfClassic);
+        }
+
         FURI_LOG_D(TAG, "MFC type: %d", mfc_data->type);
         mfc_event->data->poller_mode.mode = MfClassicPollerModeDictAttack;
         mfc_event->data->poller_mode.data = mfc_data;


### PR DESCRIPTION
# What's new

- Fixed a bug where keys found from user dictionary were discarded when switching to system dictionary (#209)

# Verification 

- See files in #209, all keys should be found after the attack.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
