### PR TITLE
Update nfc_magic_scene_not_magic.c

### DIFF
--- a/nfc_magic/scenes/nfc_magic_scene_not_magic.c
+++ b/nfc_magic/scenes/nfc_magic_scene_not_magic.c
@@ -14,7 +14,7 @@ void nfc_magic_scene_not_magic_on_enter(void* context) {
     notification_message(instance->notifications, &sequence_error);
 
     widget_add_string_element(
-        widget, 3, 4, AlignLeft, AlignTop, FontPrimary, "This is wrong card");
+        widget, 3, 4, AlignLeft, AlignTop, FontPrimary, "Incorrect card type");
     widget_add_string_multiline_element(
         widget,
         4,
@@ -22,7 +22,7 @@ void nfc_magic_scene_not_magic_on_enter(void* context) {
         AlignLeft,
         AlignTop,
         FontSecondary,
-        "Not magic or unsupported\ncard. Only Gen1 and \nGen4 UMC cards supported.");
+        "Not magic or unsupported\ncard. Only Gen1, Gen2 and \nGen4 UMC cards supported.");
     widget_add_button_element(
         widget, GuiButtonTypeLeft, "Retry", nfc_magic_scene_not_magic_widget_callback, instance);
 


### PR DESCRIPTION
Changed "this is wrong card" to "Incorrect card type" & added Gen2 to list of supported magic card types

# What's new

- Changed header text from "This is wrong card" to "Incorrect card type"
- Added Gen2 to list of supported magic chipsets 

# Verification 

- Try writing to a mifare classic card that isn't magic and/or gen1,2,4UMC

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
