### PR TITLE
Fix incorrect line breaks in SPI Memory Manager

### DIFF
--- a/spi_mem_manager/.catalog/changelog.md
+++ b/spi_mem_manager/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.4
+   Fixed UI rendering bug related to line breaks
 ## 1.3
    XM25QH64C and XM25QH128A flash chip support added
 ## 1.2

--- a/spi_mem_manager/.catalog/changelog.md
+++ b/spi_mem_manager/.catalog/changelog.md
@@ -1,5 +1,5 @@
 ## 1.4
-   Fixed UI rendering bug related to line breaks
+ - Fixed UI rendering bug related to line breaks
  - Removed call to legacy SDK API
 ## 1.3
    XM25QH64C and XM25QH128A flash chip support added

--- a/spi_mem_manager/application.fam
+++ b/spi_mem_manager/application.fam
@@ -6,7 +6,7 @@ App(
     requires=["gui"],
     stack_size=1 * 2048,
     fap_description="Application for reading and writing 25-series SPI memory chips",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_icon="images/Dip8_10px.png",
     fap_category="GPIO",
     fap_icon_assets="images",

--- a/spi_mem_manager/scenes/spi_mem_scene_chip_detect_fail.c
+++ b/spi_mem_manager/scenes/spi_mem_scene_chip_detect_fail.c
@@ -26,13 +26,13 @@ void spi_mem_scene_chip_detect_fail_on_enter(void* context) {
         app->widget, 64, 20, AlignCenter, AlignBottom, FontPrimary, "unknown SPI chip");
     furi_string_printf(str, "Vendor\nid: 0x%02X", spi_mem_chip_get_vendor_id(app->chip_info));
     widget_add_string_multiline_element(
-        app->widget, 16, 44, AlignCenter, AlignBottom, FontSecondary, furi_string_get_cstr(str));
+        app->widget, 18, 44, AlignCenter, AlignBottom, FontSecondary, furi_string_get_cstr(str));
     furi_string_printf(str, "Type\nid: 0x%02X", spi_mem_chip_get_type_id(app->chip_info));
     widget_add_string_multiline_element(
         app->widget, 64, 44, AlignCenter, AlignBottom, FontSecondary, furi_string_get_cstr(str));
     furi_string_printf(str, "Capacity\nid: 0x%02X", spi_mem_chip_get_capacity_id(app->chip_info));
     widget_add_string_multiline_element(
-        app->widget, 110, 44, AlignCenter, AlignBottom, FontSecondary, furi_string_get_cstr(str));
+        app->widget, 108, 44, AlignCenter, AlignBottom, FontSecondary, furi_string_get_cstr(str));
     furi_string_free(str);
     view_dispatcher_switch_to_view(app->view_dispatcher, SPIMemViewWidget);
 }


### PR DESCRIPTION
# What's new
  - Fixed incorrect line breaking as reported in #180 by moving the text two pixels to the side. The text on the opposite side of the screen has also been moved for symmetry.

# Verification 
  - Run the app and verify that the text breaks normally

# Checklist (For Reviewer)
- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
