### PR TITLE
Yank deprecated `view_dispatcher_enable_queue`

### DIFF
--- a/air_mouse/.catalog/CHANGELOG.md
+++ b/air_mouse/.catalog/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.3
+ - Removed call to legacy SDK API
 ## 1.2
  - Migration to new BLE profile
 ## 1.1

--- a/air_mouse/air_mouse_app.c
+++ b/air_mouse/air_mouse_app.c
@@ -206,7 +206,6 @@ static AirMouseApp* air_mouse_alloc(void) {
 
     app->gui = furi_record_open(RECORD_GUI);
     app->view_dispatcher = view_dispatcher_alloc();
-    view_dispatcher_enable_queue(app->view_dispatcher);
     view_dispatcher_attach_to_gui(app->view_dispatcher, app->gui, ViewDispatcherTypeFullscreen);
 
     app->air_mouse_view = air_mouse_view_alloc(air_mouse_hid_deinit, app);

--- a/air_mouse/application.fam
+++ b/air_mouse/application.fam
@@ -1,7 +1,7 @@
 App(
     appid="vgm_air_mouse",
     name="Air Mouse",
-    fap_version="1.2",
+    fap_version="1.3",
     fap_description="Turn Flipper Zero with the Video Game Module into an air mouse",
     apptype=FlipperAppType.EXTERNAL,
     entry_point="air_mouse_app",

--- a/avr_isp_programmer/.catalog/changelog.md
+++ b/avr_isp_programmer/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.4
+ - Removed call to legacy SDK API
 ## 1.3
  - Update API v60.3
 ## 1.2

--- a/avr_isp_programmer/application.fam
+++ b/avr_isp_programmer/application.fam
@@ -6,7 +6,7 @@ App(
     requires=["gui"],
     stack_size=4 * 1024,
     fap_description="Application for flashing AVR microcontrollers",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_icon="avr_app_icon_10px.png",
     fap_category="GPIO",
     fap_icon_assets="images",

--- a/avr_isp_programmer/avr_isp_app.c
+++ b/avr_isp_programmer/avr_isp_app.c
@@ -31,7 +31,6 @@ AvrIspApp* avr_isp_app_alloc() {
     // View Dispatcher
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&avr_isp_scene_handlers, app);
-    view_dispatcher_enable_queue(app->view_dispatcher);
 
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_custom_event_callback(

--- a/dap_link/application.fam
+++ b/dap_link/application.fam
@@ -9,7 +9,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Enables use of Flipper as a debug probe for ARM devices, implements the CMSIS-DAP protocol",
-    fap_version="1.2",
+    fap_version="1.3",
     fap_icon="dap_link.png",
     fap_category="GPIO",
     fap_private_libs=[

--- a/dap_link/gui/dap_gui.c
+++ b/dap_link/gui/dap_gui.c
@@ -26,7 +26,6 @@ DapGuiApp* dap_gui_alloc() {
     app->gui = furi_record_open(RECORD_GUI);
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&dap_scene_handlers, app);
-    view_dispatcher_enable_queue(app->view_dispatcher);
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
 
     view_dispatcher_set_custom_event_callback(app->view_dispatcher, dap_gui_custom_event_callback);

--- a/mass_storage/.catalog/CHANGELOG.md
+++ b/mass_storage/.catalog/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v.1.4
+Removed call to legacy SDK API
+
 ## v.1.3
 
 Minimal changes for recent API updates

--- a/mass_storage/application.fam
+++ b/mass_storage/application.fam
@@ -9,7 +9,7 @@ App(
     ],
     stack_size=2 * 1024,
     fap_description="Implements a mass storage device over USB for disk images",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_icon="assets/mass_storage_10px.png",
     fap_icon_assets="assets",
     fap_category="USB",

--- a/mass_storage/mass_storage_app.c
+++ b/mass_storage/mass_storage_app.c
@@ -47,7 +47,6 @@ MassStorageApp* mass_storage_app_alloc(char* arg) {
     app->dialogs = furi_record_open(RECORD_DIALOGS);
 
     app->view_dispatcher = view_dispatcher_alloc();
-    view_dispatcher_enable_queue(app->view_dispatcher);
 
     app->scene_manager = scene_manager_alloc(&mass_storage_scene_handlers, app);
 

--- a/nfc_magic/.catalog/changelog.md
+++ b/nfc_magic/.catalog/changelog.md
@@ -1,3 +1,6 @@
+## 1.12
+ - Removed call to legacy SDK API
+
 ## 1.11
  - Fixed Mifare Ultralight types with latest API update
 

--- a/nfc_magic/application.fam
+++ b/nfc_magic/application.fam
@@ -10,7 +10,7 @@ App(
     ],
     stack_size=4 * 1024,
     fap_description="Application for writing to NFC tags with modifiable sector 0",
-    fap_version="1.11",
+    fap_version="1.12",
     fap_icon="assets/125_10px.png",
     fap_category="NFC",
     fap_icon_assets="assets",

--- a/nfc_magic/nfc_magic_app.c
+++ b/nfc_magic/nfc_magic_app.c
@@ -40,7 +40,6 @@ NfcMagicApp* nfc_magic_app_alloc() {
 
     instance->view_dispatcher = view_dispatcher_alloc();
     instance->scene_manager = scene_manager_alloc(&nfc_magic_scene_handlers, instance);
-    view_dispatcher_enable_queue(instance->view_dispatcher);
     view_dispatcher_set_event_callback_context(instance->view_dispatcher, instance);
     view_dispatcher_set_custom_event_callback(
         instance->view_dispatcher, nfc_magic_app_custom_event_callback);

--- a/nfc_rfid_detector/.catalog/changelog.md
+++ b/nfc_rfid_detector/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.4
+ - Removed call to legacy SDK API
 ## 1.3
  - Сhange GUI
 ## 1.2

--- a/nfc_rfid_detector/application.fam
+++ b/nfc_rfid_detector/application.fam
@@ -7,7 +7,7 @@ App(
     requires=["gui"],
     stack_size=4 * 1024,
     fap_description="Identify the reader type: NFC (13 MHz) and/or RFID (125 KHz).",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_icon="nfc_rfid_detector_icon_10px.png",
     fap_category="Tools",
     fap_icon_assets="images",

--- a/nfc_rfid_detector/nfc_rfid_detector_app.c
+++ b/nfc_rfid_detector/nfc_rfid_detector_app.c
@@ -30,7 +30,6 @@ NfcRfidDetectorApp* nfc_rfid_detector_app_alloc() {
     // View Dispatcher
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&nfc_rfid_detector_scene_handlers, app);
-    view_dispatcher_enable_queue(app->view_dispatcher);
 
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_custom_event_callback(

--- a/signal_generator/application.fam
+++ b/signal_generator/application.fam
@@ -6,7 +6,7 @@ App(
     requires=["gui"],
     stack_size=1 * 1024,
     fap_description="Control GPIO pins to generate digital signals",
-    fap_version="1.0",
+    fap_version="1.1",
     fap_icon="signal_gen_10px.png",
     fap_category="GPIO",
     fap_icon_assets="icons",

--- a/signal_generator/signal_gen_app.c
+++ b/signal_generator/signal_gen_app.c
@@ -28,7 +28,6 @@ SignalGenApp* signal_gen_app_alloc() {
 
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&signal_gen_scene_handlers, app);
-    view_dispatcher_enable_queue(app->view_dispatcher);
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
 
     view_dispatcher_set_custom_event_callback(

--- a/spi_mem_manager/.catalog/changelog.md
+++ b/spi_mem_manager/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.4
+ - Removed call to legacy SDK API
 ## 1.3
    XM25QH64C and XM25QH128A flash chip support added
 ## 1.2

--- a/spi_mem_manager/application.fam
+++ b/spi_mem_manager/application.fam
@@ -6,7 +6,7 @@ App(
     requires=["gui"],
     stack_size=1 * 2048,
     fap_description="Application for reading and writing 25-series SPI memory chips",
-    fap_version="1.3",
+    fap_version="1.4",
     fap_icon="images/Dip8_10px.png",
     fap_category="GPIO",
     fap_icon_assets="images",

--- a/spi_mem_manager/spi_mem_app.c
+++ b/spi_mem_manager/spi_mem_app.c
@@ -40,7 +40,6 @@ SPIMemApp* spi_mem_alloc(void) {
     // Migrate data from old sd-card folder
     storage_common_migrate(instance->storage, EXT_PATH("spimem"), STORAGE_APP_DATA_PATH_PREFIX);
 
-    view_dispatcher_enable_queue(instance->view_dispatcher);
     view_dispatcher_set_event_callback_context(instance->view_dispatcher, instance);
     view_dispatcher_set_custom_event_callback(
         instance->view_dispatcher, spi_mem_custom_event_callback);

--- a/video_game_module_tool/.catalog/CHANGELOG.md
+++ b/video_game_module_tool/.catalog/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.3
+ - Removed call to legacy SDK API
 ## 1.2
  - Fix crash due to log output in critical section
  - Fix crash when built with DEBUG=1

--- a/video_game_module_tool/app.c
+++ b/video_game_module_tool/app.c
@@ -43,7 +43,6 @@ static App* app_alloc() {
     view_dispatcher_add_view(
         app->view_dispatcher, ViewIdProgress, progress_get_view(app->progress));
 
-    view_dispatcher_enable_queue(app->view_dispatcher);
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_custom_event_callback(app->view_dispatcher, custom_event_callback);
     view_dispatcher_set_navigation_event_callback(app->view_dispatcher, back_event_callback);

--- a/video_game_module_tool/application.fam
+++ b/video_game_module_tool/application.fam
@@ -9,7 +9,7 @@ App(
     ],
     stack_size=2048,
     fap_description="This app is a standalone firmware updater/installer for the Video Game Module",
-    fap_version="1.2",
+    fap_version="1.3",
     fap_icon="vgm_tool.png",
     fap_category="Tools",
     fap_icon_assets="icons",

--- a/weather_station/.catalog/changelog.md
+++ b/weather_station/.catalog/changelog.md
@@ -1,3 +1,5 @@
+## 1.8
+ - Removed call to legacy SDK API
 ## 1.7
  - Added external CC1101 radio modules support
 ## 1.6

--- a/weather_station/application.fam
+++ b/weather_station/application.fam
@@ -7,7 +7,7 @@ App(
     requires=["gui"],
     stack_size=4 * 1024,
     fap_description="Receive weather data from a wide range of supported Sub-1GHz remote sensor",
-    fap_version="1.7",
+    fap_version="1.8",
     fap_icon="weather_station_10px.png",
     fap_category="Sub-GHz",
     fap_icon_assets="images",

--- a/weather_station/weather_station_app.c
+++ b/weather_station/weather_station_app.c
@@ -31,7 +31,6 @@ WeatherStationApp* weather_station_app_alloc() {
     // View Dispatcher
     app->view_dispatcher = view_dispatcher_alloc();
     app->scene_manager = scene_manager_alloc(&weather_station_scene_handlers, app);
-    view_dispatcher_enable_queue(app->view_dispatcher);
 
     view_dispatcher_set_event_callback_context(app->view_dispatcher, app);
     view_dispatcher_set_custom_event_callback(


### PR DESCRIPTION
# What's new
  - Removed calls to the deprecated `view_dispatcher_enable_queue` SDK API function

# Verification 
  - This change shouldn't break anything, as the described API function is essentially a no-op

# Checklist (For Reviewer)
- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [x] I've built this code, uploaded it to the device and verified feature/bugfix
