### PR TITLE
Signal generator crash fix

### DIFF
--- a/signal_generator/scenes/signal_gen_scene_pwm.c
+++ b/signal_generator/scenes/signal_gen_scene_pwm.c
@@ -53,7 +53,8 @@ bool signal_gen_scene_pwm_on_event(void* context, SceneManagerEvent event) {
         } else if(event.event == SignalGenPwmEventChannelChange) {
             consumed = true;
             // Stop previous channel PWM
-            if(furi_hal_pwm_is_running(app->pwm_ch_prev)) {
+            if(app->pwm_ch_prev != FuriHalPwmOutputIdNone &&
+               furi_hal_pwm_is_running(app->pwm_ch_prev)) {
                 furi_hal_pwm_stop(app->pwm_ch_prev);
             }
 

--- a/signal_generator/views/signal_gen_pwm.c
+++ b/signal_generator/views/signal_gen_pwm.c
@@ -35,8 +35,8 @@ typedef struct {
 #define VALUE_X 100
 #define VALUE_W 45
 
-#define FREQ_VALUE_X 62
-#define FREQ_MAX 1000000UL
+#define FREQ_VALUE_X   62
+#define FREQ_MAX       1000000UL
 #define FREQ_DIGITS_NB 7
 
 static void pwm_set_config(SignalGenPwm* pwm) {


### PR DESCRIPTION
# What's new
  - Fixes FL-3982

# Verification 
  - Open Signal Generator
  - Select PWM Generator
  - Verify that Flipper has not crashed

# Checklist (For Reviewer)
  - [x] PR has description of feature/bug or link to Confluence/Jira task
  - [x] Description contains actions to verify feature/bugfix
  - [x] I've built this code, uploaded it to the device and verified feature/bugfix
