### PR TITLE
NFC Magic: Ultimate Magic Gen4 Max Block Number Set Incorrectly for the NTAG Protocol

### DIFF
--- a/nfc_magic/magic/protocols/gen4/gen4_poller.c
+++ b/nfc_magic/magic/protocols/gen4/gen4_poller.c
@@ -400,7 +400,6 @@ static NfcCommand gen4_poller_write_mf_ultralight(Gen4Poller* instance) {
                 instance->total_blocks = 128;
                 break;
 
-
             case MfUltralightTypeOrigin:
                 FURI_LOG_D(TAG, "Ultralight type");
                 instance->config.data_parsed.mfu_mode = Gen4UltralightModeUL;

--- a/nfc_magic/magic/protocols/gen4/gen4_poller.c
+++ b/nfc_magic/magic/protocols/gen4/gen4_poller.c
@@ -372,33 +372,33 @@ static NfcCommand gen4_poller_write_mf_ultralight(Gen4Poller* instance) {
             instance->config.data_parsed.protocol = Gen4ProtocolMfUltralight;
             switch(mfu_data->type) {
             case MfUltralightTypeNTAG203:
-				FURI_LOG_D(TAG, "NTAG203 type");
-				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
-				instance->total_blocks = 42;
-				break;
-			case MfUltralightTypeNTAG213:
-				FURI_LOG_D(TAG, "NTAG213 type");
-				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
-				instance->total_blocks = 45;
-				break;
-			case MfUltralightTypeNTAG215:
-				FURI_LOG_D(TAG, "NTAG215 type");
-				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
-				instance->total_blocks = 135;
-				break;
-			case MfUltralightTypeNTAG216:
-				FURI_LOG_D(TAG, "NTAG216 type");
-				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
-				instance->total_blocks = 231;
-				break;
+                FURI_LOG_D(TAG, "NTAG203 type");
+                instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+                instance->total_blocks = 42;
+                break;
+            case MfUltralightTypeNTAG213:
+                FURI_LOG_D(TAG, "NTAG213 type");
+                instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+                instance->total_blocks = 45;
+                break;
+            case MfUltralightTypeNTAG215:
+                FURI_LOG_D(TAG, "NTAG215 type");
+                instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+                instance->total_blocks = 135;
+                break;
+            case MfUltralightTypeNTAG216:
+                FURI_LOG_D(TAG, "NTAG216 type");
+                instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+                instance->total_blocks = 231;
+                break;
             case MfUltralightTypeNTAGI2C1K:
             case MfUltralightTypeNTAGI2C2K:
             case MfUltralightTypeNTAGI2CPlus1K:
             case MfUltralightTypeNTAGI2CPlus2K:
                 FURI_LOG_D(TAG, "NTAG type");
-				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
-				instance->total_blocks = 128;
-				break;
+                instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+                instance->total_blocks = 128;
+                break;
 
 
             case MfUltralightTypeOrigin:

--- a/nfc_magic/magic/protocols/gen4/gen4_poller.c
+++ b/nfc_magic/magic/protocols/gen4/gen4_poller.c
@@ -372,17 +372,34 @@ static NfcCommand gen4_poller_write_mf_ultralight(Gen4Poller* instance) {
             instance->config.data_parsed.protocol = Gen4ProtocolMfUltralight;
             switch(mfu_data->type) {
             case MfUltralightTypeNTAG203:
-            case MfUltralightTypeNTAG213:
-            case MfUltralightTypeNTAG215:
-            case MfUltralightTypeNTAG216:
+				FURI_LOG_D(TAG, "NTAG203 type");
+				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+				instance->total_blocks = 42;
+				break;
+			case MfUltralightTypeNTAG213:
+				FURI_LOG_D(TAG, "NTAG213 type");
+				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+				instance->total_blocks = 45;
+				break;
+			case MfUltralightTypeNTAG215:
+				FURI_LOG_D(TAG, "NTAG215 type");
+				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+				instance->total_blocks = 135;
+				break;
+			case MfUltralightTypeNTAG216:
+				FURI_LOG_D(TAG, "NTAG216 type");
+				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+				instance->total_blocks = 231;
+				break;
             case MfUltralightTypeNTAGI2C1K:
             case MfUltralightTypeNTAGI2C2K:
             case MfUltralightTypeNTAGI2CPlus1K:
             case MfUltralightTypeNTAGI2CPlus2K:
                 FURI_LOG_D(TAG, "NTAG type");
-                instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
-                instance->total_blocks = 64 * 2;
-                break;
+				instance->config.data_parsed.mfu_mode = Gen4UltralightModeNTAG;
+				instance->total_blocks = 128;
+				break;
+
 
             case MfUltralightTypeOrigin:
                 FURI_LOG_D(TAG, "Ultralight type");


### PR DESCRIPTION
# What's new

- Added the appropriate number of blocks for each NTAG type

Fixes #276 

I had initially contacted the Discord for assistance regarding this issue and it seems that @hedger was pinged on taking a look.

I do apologize if this PR is inappropriate or incorrect as this is my first time and I'm quite novice. I would really appreciate any feedback and to see a resolution regarding this issue eventually. Thank you so much for your patience and understanding! ♥