### PR TITLE
mfkey: skip redundant recovery for solved static_encrypted nonces

### DIFF
--- a/mfkey/mfkey.c
+++ b/mfkey/mfkey.c
@@ -325,7 +325,7 @@ bool key_already_found_for_nonce_in_solved(
             if(nonce->ar1_enc == (crypt_word(&temp) ^ nonce->p64b)) {
                 return true;
             }
-        } else if(nonce->attack == static_nested) {
+        } else if(nonce->attack == static_nested || nonce->attack == static_encrypted) {
             uint32_t expected_ks1 = crypt_word_ret(&temp, nonce->uid_xor_nt0, 0);
             if(nonce->ks1_1_enc == expected_ks1) {
                 return true;


### PR DESCRIPTION
# What's new

`key_already_found_for_nonce_in_solved()` skips the expensive `recover()` when a key found earlier in the same run already solves the current nonce. It handles `mfkey32` and `static_nested`, but `static_encrypted` falls through the `if/else if` and returns `false`, so those nonces re-run recovery even when an earlier key already covers them.

Its sibling `key_already_found_for_nonce_in_dict()` in `init_plugin.c` already treats `static_nested` and `static_encrypted` together, with the identical check:

```c
uint32_t expected_ks1 = crypt_word_ret(&temp, nonce->uid_xor_nt0, 0);
if (nonce->ks1_1_enc == expected_ks1) { ... }
```

So this closes the gap between the two functions. It only changes how much work is skipped, never the result. If the key really solves the nonce, the `ks1_1_enc` comparison matches and recovery is correctly skipped; otherwise it falls through to `recover()` exactly as before.

The `.nested.log` attached to #305 is a batch of seven identical `static_encrypted` nonces, which is the case this avoids re-solving. It doesn't change the recovery result in #305; it just stops redoing the same work on every duplicate nonce, and `static_encrypted` runs `recover()` at half speed, so those duplicates aren't cheap.

# Verification

Compared the two functions directly: the `static` branch is byte-for-byte the same crypto in both, and `key_already_found_for_nonce_in_dict` (which is on the live dictionary-lookup path in `init_plugin.c`) already includes `static_encrypted` in that branch. The change here is adding the same enum value to the `else if` in `mfkey.c`.

I don't have a Flipper to flash right now, so this isn't verified on-device — it's a one-value change matching an already-shipped sibling, and there's no new crypto reasoning in it.

# Checklist (For Reviewer)

- [x] PR has description of feature/bug or link to Confluence/Jira task
- [x] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
